### PR TITLE
fix(audit): P1 securite/remboursements + P2 checkout, RLS et abonnements physiques

### DIFF
--- a/src/hooks/digital/useCustomerDownloads.ts
+++ b/src/hooks/digital/useCustomerDownloads.ts
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { PAID_REVENUE_ELIGIBLE_STATUSES } from '@/lib/orders/order-status';
 
 const DOWNLOAD_EVENT_FIELDS = 'id, download_id, type, message, created_at';
 
 /**
- * Téléchargement client
+ * Téléchargement client (vue vendeur — agrégée depuis digital_licenses)
  */
 export interface CustomerDownload {
   id: string;
@@ -25,108 +26,184 @@ export interface CustomerDownload {
   amountPaid?: number;
 }
 
+type LicenseRow = {
+  id: string;
+  license_key: string | null;
+  status: string;
+  customer_email: string | null;
+  customer_name: string | null;
+  activated_at: string | null;
+  created_at: string;
+  digital_product_id: string;
+  order_id: string | null;
+  current_activations: number | null;
+  max_activations: number | null;
+  issued_at: string;
+  expires_at: string | null;
+  digital_products: {
+    id: string;
+    products: { id: string; name: string; store_id: string } | null;
+  } | null;
+  orders: {
+    total_amount: number | null;
+    payment_status: string | null;
+    status: string | null;
+    created_at: string;
+  } | null;
+};
+
+function mapLicenseToCustomerDownload(d: LicenseRow): CustomerDownload {
+  const product = d.digital_products?.products;
+  return {
+    id: d.id,
+    customerId: '',
+    customerName: d.customer_name || 'Inconnu',
+    customerEmail: d.customer_email || '',
+    productId: d.digital_product_id,
+    productName: product?.name || 'Produit supprimé',
+    downloadCount: d.current_activations ?? 0,
+    downloadLimit: d.max_activations ?? undefined,
+    licenseKey: d.license_key ?? undefined,
+    status: (d.status as CustomerDownload['status']) || 'pending',
+    purchaseDate: d.orders?.created_at || d.issued_at || d.created_at,
+    lastDownloadDate: d.activated_at ?? undefined,
+    expiryDate: d.expires_at ?? undefined,
+    amountPaid: d.orders?.total_amount ?? undefined,
+  };
+}
+
+async function fetchStoreDigitalProductIds(userId: string): Promise<string[]> {
+  const { data: stores, error: storesError } = await supabase
+    .from('stores')
+    .select('id')
+    .eq('user_id', userId);
+
+  if (storesError) throw storesError;
+  const storeIds = stores?.map(s => s.id) ?? [];
+  if (storeIds.length === 0) return [];
+
+  const { data: products, error: productsError } = await supabase
+    .from('products')
+    .select('id')
+    .in('store_id', storeIds)
+    .eq('product_type', 'digital');
+
+  if (productsError) throw productsError;
+  const productIds = products?.map(p => p.id) ?? [];
+  if (productIds.length === 0) return [];
+
+  const { data: digitalRows, error: digitalError } = await supabase
+    .from('digital_products')
+    .select('id')
+    .in('product_id', productIds);
+
+  if (digitalError) throw digitalError;
+  return digitalRows?.map(d => d.id) ?? [];
+}
+
 /**
- * useCustomerDownloads - Hook pour lister tous les téléchargements clients
+ * useCustomerDownloads - Licences / téléchargements des produits digitaux du vendeur
  */
 export const useCustomerDownloads = () => {
   return useQuery({
     queryKey: ['customerDownloads'],
     queryFn: async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) throw new Error('Non authentifié');
 
-      // Récupérer les produits de l'utilisateur
-      const { data: products, error: productsError } = await supabase
-        .from('digital_products')
-        .select('id')
-        .eq('user_id', user.id);
+      const digitalProductIds = await fetchStoreDigitalProductIds(user.id);
+      if (digitalProductIds.length === 0) return [];
 
-      if (productsError) throw productsError;
-
-      const productIds = products.map((p) => p.id);
-      if (productIds.length === 0) return [];
-
-      // Récupérer les téléchargements
       const { data, error } = await supabase
-        .from('customer_downloads')
-        .select(`
-          *,
-          customer:customers(name, email),
-          product:digital_products(name)
-        `)
-        .in('product_id', productIds)
-        .order('purchase_date', { ascending: false });
+        .from('digital_licenses')
+        .select(
+          `
+          id,
+          license_key,
+          status,
+          customer_email,
+          customer_name,
+          activated_at,
+          created_at,
+          digital_product_id,
+          order_id,
+          current_activations,
+          max_activations,
+          issued_at,
+          expires_at,
+          digital_products (
+            id,
+            products ( id, name, store_id )
+          ),
+          orders ( total_amount, payment_status, created_at, status )
+        `
+        )
+        .in('digital_product_id', digitalProductIds)
+        .order('created_at', { ascending: false });
 
       if (error) throw error;
 
-      return data.map((d: any) => ({
-        id: d.id,
-        customerId: d.customer_id,
-        customerName: d.customer?.name || 'Inconnu',
-        customerEmail: d.customer?.email || '',
-        productId: d.product_id,
-        productName: d.product?.name || 'Produit supprimé',
-        downloadCount: d.download_count || 0,
-        downloadLimit: d.download_limit,
-        licenseKey: d.license_key,
-        status: d.status,
-        purchaseDate: d.purchase_date,
-        lastDownloadDate: d.last_download_date,
-        expiryDate: d.expiry_date,
-        ipAddress: d.ip_address,
-        location: d.location,
-        amountPaid: d.amount_paid,
-      })) as CustomerDownload[];
+      return (data as LicenseRow[])
+        .filter(
+          row =>
+            !row.orders?.payment_status ||
+            (row.orders.payment_status === 'paid' &&
+              PAID_REVENUE_ELIGIBLE_STATUSES.includes(
+                row.orders.status as (typeof PAID_REVENUE_ELIGIBLE_STATUSES)[number]
+              ))
+        )
+        .map(mapLicenseToCustomerDownload);
     },
   });
 };
 
 /**
- * useCustomerDownloadsByProduct - Hook pour filtrer par produit
+ * useCustomerDownloadsByProduct - digital_product_id
  */
-export const useCustomerDownloadsByProduct = (productId: string | undefined) => {
+export const useCustomerDownloadsByProduct = (digitalProductId: string | undefined) => {
   return useQuery({
-    queryKey: ['customerDownloads', 'product', productId],
+    queryKey: ['customerDownloads', 'product', digitalProductId],
     queryFn: async () => {
-      if (!productId) throw new Error('ID produit manquant');
+      if (!digitalProductId) throw new Error('ID produit manquant');
 
       const { data, error } = await supabase
-        .from('customer_downloads')
-        .select(`
-          *,
-          customer:customers(name, email),
-          product:digital_products(name)
-        `)
-        .eq('product_id', productId)
-        .order('purchase_date', { ascending: false });
+        .from('digital_licenses')
+        .select(
+          `
+          id,
+          license_key,
+          status,
+          customer_email,
+          customer_name,
+          activated_at,
+          created_at,
+          digital_product_id,
+          order_id,
+          current_activations,
+          max_activations,
+          issued_at,
+          expires_at,
+          digital_products (
+            id,
+            products ( id, name, store_id )
+          ),
+          orders ( total_amount, payment_status, created_at, status )
+        `
+        )
+        .eq('digital_product_id', digitalProductId)
+        .order('created_at', { ascending: false });
 
       if (error) throw error;
-
-      return data.map((d: any) => ({
-        id: d.id,
-        customerId: d.customer_id,
-        customerName: d.customer?.name || 'Inconnu',
-        customerEmail: d.customer?.email || '',
-        productId: d.product_id,
-        productName: d.product?.name || 'Produit supprimé',
-        downloadCount: d.download_count || 0,
-        downloadLimit: d.download_limit,
-        licenseKey: d.license_key,
-        status: d.status,
-        purchaseDate: d.purchase_date,
-        lastDownloadDate: d.last_download_date,
-        expiryDate: d.expiry_date,
-        ipAddress: d.ip_address,
-        location: d.location,
-        amountPaid: d.amount_paid,
-      })) as CustomerDownload[];
+      return (data as LicenseRow[]).map(mapLicenseToCustomerDownload);
     },
-    enabled: !!productId,
+    enabled: !!digitalProductId,
   });
 };
 
 /**
- * useCustomerDownloadsByCustomer - Hook pour filtrer par client
+ * useCustomerDownloadsByCustomer - email client
  */
 export const useCustomerDownloadsByCustomer = (customerId: string | undefined) => {
   return useQuery({
@@ -134,43 +211,59 @@ export const useCustomerDownloadsByCustomer = (customerId: string | undefined) =
     queryFn: async () => {
       if (!customerId) throw new Error('ID client manquant');
 
+      const { data: customer, error: customerError } = await supabase
+        .from('customers')
+        .select('id, email')
+        .eq('id', customerId)
+        .single();
+
+      if (customerError || !customer?.email) throw customerError ?? new Error('Client introuvable');
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error('Non authentifié');
+
+      const digitalProductIds = await fetchStoreDigitalProductIds(user.id);
+      if (digitalProductIds.length === 0) return [];
+
       const { data, error } = await supabase
-        .from('customer_downloads')
-        .select(`
-          *,
-          customer:customers(name, email),
-          product:digital_products(name)
-        `)
-        .eq('customer_id', customerId)
-        .order('purchase_date', { ascending: false });
+        .from('digital_licenses')
+        .select(
+          `
+          id,
+          license_key,
+          status,
+          customer_email,
+          customer_name,
+          activated_at,
+          created_at,
+          digital_product_id,
+          order_id,
+          current_activations,
+          max_activations,
+          issued_at,
+          expires_at,
+          digital_products (
+            id,
+            products ( id, name, store_id )
+          ),
+          orders ( total_amount, payment_status, created_at, status )
+        `
+        )
+        .in('digital_product_id', digitalProductIds)
+        .eq('customer_email', customer.email)
+        .order('created_at', { ascending: false });
 
       if (error) throw error;
-
-      return data.map((d: any) => ({
-        id: d.id,
-        customerId: d.customer_id,
-        customerName: d.customer?.name || 'Inconnu',
-        customerEmail: d.customer?.email || '',
-        productId: d.product_id,
-        productName: d.product?.name || 'Produit supprimé',
-        downloadCount: d.download_count || 0,
-        downloadLimit: d.download_limit,
-        licenseKey: d.license_key,
-        status: d.status,
-        purchaseDate: d.purchase_date,
-        lastDownloadDate: d.last_download_date,
-        expiryDate: d.expiry_date,
-        ipAddress: d.ip_address,
-        location: d.location,
-        amountPaid: d.amount_paid,
-      })) as CustomerDownload[];
+      return (data as LicenseRow[]).map(mapLicenseToCustomerDownload);
     },
     enabled: !!customerId,
   });
 };
 
 /**
- * useRevokeDownloadAccess - Hook pour révoquer un accès de téléchargement
+ * useRevokeDownloadAccess - Révoque une licence digitale
  */
 export const useRevokeDownloadAccess = () => {
   const queryClient = useQueryClient();
@@ -178,7 +271,7 @@ export const useRevokeDownloadAccess = () => {
   return useMutation({
     mutationFn: async ({ downloadId, reason }: { downloadId: string; reason?: string }) => {
       const { data, error } = await supabase
-        .from('customer_downloads')
+        .from('digital_licenses')
         .update({
           status: 'revoked',
           updated_at: new Date().toISOString(),
@@ -187,9 +280,6 @@ export const useRevokeDownloadAccess = () => {
         .select()
         .single();
 
-      if (error) throw error;
-
-      // Créer un événement de révocation
       if (reason) {
         await supabase.from('download_events').insert({
           download_id: downloadId,
@@ -198,6 +288,7 @@ export const useRevokeDownloadAccess = () => {
         });
       }
 
+      if (error) throw error;
       return data;
     },
     onSuccess: () => {
@@ -207,32 +298,24 @@ export const useRevokeDownloadAccess = () => {
 };
 
 /**
- * useRestoreDownloadAccess - Hook pour restaurer un accès
+ * useRestoreDownloadAccess - Réactive une licence
  */
 export const useRestoreDownloadAccess = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (downloadId: string) => {
+    mutationFn: async (licenseId: string) => {
       const { data, error } = await supabase
-        .from('customer_downloads')
+        .from('digital_licenses')
         .update({
           status: 'active',
           updated_at: new Date().toISOString(),
         })
-        .eq('id', downloadId)
+        .eq('id', licenseId)
         .select()
         .single();
 
       if (error) throw error;
-
-      // Créer un événement de restauration
-      await supabase.from('download_events').insert({
-        download_id: downloadId,
-        type: 'access_granted',
-        message: 'Accès restauré',
-      });
-
       return data;
     },
     onSuccess: () => {
@@ -242,7 +325,7 @@ export const useRestoreDownloadAccess = () => {
 };
 
 /**
- * useUpdateDownloadLimit - Hook pour modifier la limite de téléchargements
+ * useUpdateDownloadLimit - Modifie max_downloads sur la licence
  */
 export const useUpdateDownloadLimit = () => {
   const queryClient = useQueryClient();
@@ -250,9 +333,9 @@ export const useUpdateDownloadLimit = () => {
   return useMutation({
     mutationFn: async ({ downloadId, newLimit }: { downloadId: string; newLimit: number }) => {
       const { data, error } = await supabase
-        .from('customer_downloads')
+        .from('digital_licenses')
         .update({
-          download_limit: newLimit,
+          max_activations: newLimit,
           updated_at: new Date().toISOString(),
         })
         .eq('id', downloadId)
@@ -269,25 +352,19 @@ export const useUpdateDownloadLimit = () => {
 };
 
 /**
- * useCustomerDownloadStats - Hook pour les statistiques des téléchargements clients
+ * useCustomerDownloadStats - Statistiques licences vendeur
  */
 export const useCustomerDownloadStats = () => {
   return useQuery({
     queryKey: ['customerDownloadStats'],
     queryFn: async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) throw new Error('Non authentifié');
 
-      // Récupérer les produits de l'utilisateur
-      const { data: products, error: productsError } = await supabase
-        .from('digital_products')
-        .select('id')
-        .eq('user_id', user.id);
-
-      if (productsError) throw productsError;
-
-      const productIds = products.map((p) => p.id);
-      if (productIds.length === 0) {
+      const digitalProductIds = await fetchStoreDigitalProductIds(user.id);
+      if (digitalProductIds.length === 0) {
         return {
           totalCustomers: 0,
           activeDownloads: 0,
@@ -297,19 +374,36 @@ export const useCustomerDownloadStats = () => {
         };
       }
 
-      // Récupérer les statistiques
-      const { data: downloads, error } = await supabase
-        .from('customer_downloads')
-        .select('status, amount_paid')
-        .in('product_id', productIds);
+      const { data: licenses, error } = await supabase
+        .from('digital_licenses')
+        .select('status, customer_email, orders(total_amount, payment_status)')
+        .in('digital_product_id', digitalProductIds);
 
       if (error) throw error;
 
-      const uniqueCustomers = new Set(downloads.map((d: any) => d.customer_id)).size;
-      const activeDownloads = downloads.filter((d: any) => d.status === 'active').length;
-      const revokedDownloads = downloads.filter((d: any) => d.status === 'revoked').length;
-      const expiredDownloads = downloads.filter((d: any) => d.status === 'expired').length;
-      const totalRevenue = downloads.reduce((sum: number, d: any) => sum + (d.amount_paid || 0), 0);
+      const rows = licenses ?? [];
+      const uniqueCustomers = new Set(
+        rows.map((d: { customer_email: string | null }) => d.customer_email).filter(Boolean)
+      ).size;
+      const activeDownloads = rows.filter((d: { status: string }) => d.status === 'active').length;
+      const revokedDownloads = rows.filter(
+        (d: { status: string }) => d.status === 'revoked'
+      ).length;
+      const expiredDownloads = rows.filter(
+        (d: { status: string }) => d.status === 'expired'
+      ).length;
+      const totalRevenue = rows.reduce(
+        (
+          sum: number,
+          d: { orders?: { total_amount?: number; payment_status?: string } | null }
+        ) => {
+          if (d.orders?.payment_status === 'paid') {
+            return sum + Number(d.orders?.total_amount ?? 0);
+          }
+          return sum;
+        },
+        0
+      );
 
       return {
         totalCustomers: uniqueCustomers,
@@ -323,7 +417,7 @@ export const useCustomerDownloadStats = () => {
 };
 
 /**
- * useDownloadEvents - Hook pour récupérer les événements de téléchargement
+ * useDownloadEvents - Événements liés à une licence (download_id = license id)
  */
 export const useDownloadEvents = (downloadId: string | undefined) => {
   return useQuery({
@@ -344,9 +438,4 @@ export const useDownloadEvents = (downloadId: string | undefined) => {
   });
 };
 
-
-
-
-
-
-
+export { DOWNLOAD_EVENT_FIELDS };

--- a/src/hooks/orders/useCreateDigitalOrder.ts
+++ b/src/hooks/orders/useCreateDigitalOrder.ts
@@ -17,6 +17,7 @@ import { useToast } from '@/hooks/use-toast';
 import { getAffiliateTrackingCookie } from '@/hooks/useAffiliateTracking';
 import { logger } from '@/lib/logger';
 import { isSupportedCurrency, type Currency } from '@/lib/currency-converter';
+import { validateCheckoutPromotion } from '@/lib/checkout/promotion';
 
 const PRODUCT_FIELDS = 'id, name, price, promotional_price, currency';
 
@@ -59,6 +60,15 @@ export interface CreateDigitalOrderOptions {
 
   /** Montant de la carte cadeau à utiliser (optionnel) */
   giftCardAmount?: number;
+
+  /** Code promo (product_promotions / validate_unified_promotion) */
+  couponCode?: string;
+
+  /** Montant de réduction promo déjà validé côté client */
+  couponDiscountAmount?: number;
+
+  /** ID promotion pour promotion_usage */
+  promotionId?: string;
 }
 
 /**
@@ -140,6 +150,9 @@ export const useCreateDigitalOrder = () => {
         licenseExpiryDays,
         giftCardId,
         giftCardAmount = 0,
+        couponCode,
+        couponDiscountAmount = 0,
+        promotionId,
       } = options;
 
       // 1. Récupérer les détails du produit
@@ -225,9 +238,27 @@ export const useCreateDigitalOrder = () => {
         licenseId = license.id;
       }
 
-      // 4. Calculer le montant final (après carte cadeau si applicable)
-      const baseAmount = product.promotional_price || product.price;
-      const finalAmount = Math.max(0, baseAmount - (giftCardAmount || 0));
+      // 4. Calculer le montant final (promo + carte cadeau)
+      const baseAmount = Number(product.promotional_price ?? product.price);
+      let promoDiscount = Math.max(0, couponDiscountAmount || 0);
+      let resolvedPromotionId = promotionId;
+
+      if (couponCode?.trim() && promoDiscount <= 0) {
+        const validation = await validateCheckoutPromotion({
+          code: couponCode,
+          storeId,
+          productIds: [productId],
+          orderAmount: baseAmount,
+          customerId,
+        });
+        if (!validation.valid) {
+          throw new Error(validation.message);
+        }
+        promoDiscount = validation.promotion.discountAmount;
+        resolvedPromotionId = validation.promotion.promotionId;
+      }
+
+      const finalAmount = Math.max(0, baseAmount - promoDiscount - (giftCardAmount || 0));
 
       // 5. Générer un numéro de commande
       const { data: orderNumberData } = await supabase.rpc('generate_order_number');
@@ -344,6 +375,17 @@ export const useCreateDigitalOrder = () => {
 
       if (orderItemError || !orderItem) {
         throw new Error("Erreur lors de la création de l'élément de commande");
+      }
+
+      if (promoDiscount > 0 && resolvedPromotionId) {
+        await supabase.from('promotion_usage').insert({
+          promotion_id: resolvedPromotionId,
+          order_id: order.id,
+          customer_id: customerId,
+          discount_amount: promoDiscount,
+          order_total_before_discount: baseAmount,
+          order_total_after_discount: finalAmount,
+        });
       }
 
       // 11. Initier le paiement Moneroo

--- a/src/lib/affiliation-tracking.ts
+++ b/src/lib/affiliation-tracking.ts
@@ -2,8 +2,8 @@
  * Service de tracking d'affiliation
  * Gère les cookies d'affiliation et la création de commissions
  */
-import { supabase } from "@/integrations/supabase/client";
-import { logger } from "./logger";
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from './logger';
 
 const AFFILIATE_COOKIE_NAME = 'emarzona_affiliate';
 const AFFILIATE_COOKIE_EXPIRY_DAYS = 30; // Par défaut, peut être surchargé par produit
@@ -13,7 +13,7 @@ const AFFILIATE_COOKIE_EXPIRY_DAYS = 30; // Par défaut, peut être surchargé p
  */
 export const getAffiliateCookie = (): string | null => {
   if (typeof document === 'undefined') return null;
-  
+
   const cookies = document.cookie.split(';');
   for (const cookie of cookies) {
     const [name, value] = cookie.trim().split('=');
@@ -27,12 +27,15 @@ export const getAffiliateCookie = (): string | null => {
 /**
  * Définit le cookie d'affiliation
  */
-export const setAffiliateCookie = (affiliateLinkId: string, expiryDays: number = AFFILIATE_COOKIE_EXPIRY_DAYS) => {
+export const setAffiliateCookie = (
+  affiliateLinkId: string,
+  expiryDays: number = AFFILIATE_COOKIE_EXPIRY_DAYS
+) => {
   if (typeof document === 'undefined') return;
-  
+
   const expiryDate = new Date();
   expiryDate.setDate(expiryDate.getDate() + expiryDays);
-  
+
   document.cookie = `${AFFILIATE_COOKIE_NAME}=${encodeURIComponent(affiliateLinkId)}; expires=${expiryDate.toUTCString()}; path=/; SameSite=Lax`;
 };
 
@@ -48,24 +51,29 @@ export const trackAffiliateClick = async (
     // Récupérer les infos du lien d'affiliation
     const { data: affiliateLink, error: linkError } = await supabase
       .from('affiliate_links')
-      .select(`
+      .select(
+        `
         id,
         affiliate_id,
         product_id,
         store_id,
         cookie_duration_days:product_affiliate_settings(cookie_duration_days)
-      `)
+      `
+      )
       .eq('id', affiliateLinkId)
       .single();
 
     if (linkError || !affiliateLink) {
       logger.error('Affiliate link not found', { affiliateLinkId, error: linkError });
-      return { success: false, error: 'Lien d\'affiliation introuvable' };
+      return { success: false, error: "Lien d'affiliation introuvable" };
     }
 
     // Récupérer la durée du cookie depuis les paramètres du produit
-    const cookieDurationSettings = affiliateLink.cookie_duration_days as { cookie_duration_days?: number }[] | null;
-    const cookieDuration = cookieDurationSettings?.[0]?.cookie_duration_days || AFFILIATE_COOKIE_EXPIRY_DAYS;
+    const cookieDurationSettings = affiliateLink.cookie_duration_days as
+      | { cookie_duration_days?: number }[]
+      | null;
+    const cookieDuration =
+      cookieDurationSettings?.[0]?.cookie_duration_days || AFFILIATE_COOKIE_EXPIRY_DAYS;
 
     // Créer un enregistrement de clic
     const trackingCookie = `${affiliateLinkId}-${Date.now()}`;
@@ -104,7 +112,7 @@ export const trackAffiliateClick = async (
     logger.log('Affiliate click tracked', { affiliateLinkId, trackingCookie });
 
     return { success: true, tracking_cookie: trackingCookie };
-  } catch ( _error: unknown) {
+  } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue';
     logger.error('Error in trackAffiliateClick', { error: errorMessage });
     return { success: false, error: errorMessage };
@@ -121,7 +129,7 @@ export const getAffiliateInfo = async (): Promise<{
   tracking_cookie: string | null;
 }> => {
   const trackingCookie = getAffiliateCookie();
-  
+
   if (!trackingCookie) {
     return {
       affiliate_link_id: null,
@@ -159,7 +167,7 @@ export const getAffiliateInfo = async (): Promise<{
       product_id: click.product_id,
       tracking_cookie: trackingCookie,
     };
-  } catch ( _error: unknown) {
+  } catch (error: unknown) {
     logger.error('Error getting affiliate info', { error });
     return {
       affiliate_link_id: null,
@@ -189,13 +197,14 @@ export const createAffiliateCommission = async (
 
     if (!trackingCookie) {
       logger.info('No affiliate tracking cookie found', { orderId });
-      return { success: false, error: 'Aucun cookie d\'affiliation trouvé' };
+      return { success: false, error: "Aucun cookie d'affiliation trouvé" };
     }
 
     // Récupérer les infos du clic d'affiliation
     const { data: click, error: clickError } = await supabase
       .from('affiliate_clicks')
-      .select(`
+      .select(
+        `
         id,
         affiliate_link_id,
         affiliate_id,
@@ -208,7 +217,8 @@ export const createAffiliateCommission = async (
             min_order_amount
           )
         )
-      `)
+      `
+      )
       .eq('tracking_cookie', trackingCookie)
       .eq('product_id', productId)
       .eq('converted', false)
@@ -216,7 +226,7 @@ export const createAffiliateCommission = async (
 
     if (clickError || !click) {
       logger.warn('Affiliate click not found for commission', { trackingCookie, productId });
-      return { success: false, error: 'Clic d\'affiliation non trouvé' };
+      return { success: false, error: "Clic d'affiliation non trouvé" };
     }
 
     type AffiliateSettings = {
@@ -225,29 +235,40 @@ export const createAffiliateCommission = async (
       fixed_commission_amount?: number | null;
       min_order_amount?: number | null;
     };
-    const clickWithLinks = click as { 
+    const clickWithLinks = click as {
       id: string;
       affiliate_link_id: string;
       affiliate_id: string;
       product_id: string;
-      affiliate_links?: { product_affiliate_settings?: AffiliateSettings[] } 
+      affiliate_links?: { product_affiliate_settings?: AffiliateSettings[] };
     };
     const settings = clickWithLinks.affiliate_links?.product_affiliate_settings?.[0];
     if (!settings) {
       logger.warn('Product affiliate settings not found', { productId });
-      return { success: false, error: 'Paramètres d\'affiliation non trouvés' };
+      return { success: false, error: "Paramètres d'affiliation non trouvés" };
     }
 
     // Vérifier le montant minimum
     if (settings.min_order_amount && orderTotal < settings.min_order_amount) {
-      logger.info('Order total below minimum for commission', { orderTotal, minOrderAmount: settings.min_order_amount });
+      logger.info('Order total below minimum for commission', {
+        orderTotal,
+        minOrderAmount: settings.min_order_amount,
+      });
       return { success: false, error: 'Montant de commande insuffisant' };
     }
 
-    // Calculer la commission
-    let  commissionAmount= 0;
+    const { data: storeRow } = await supabase
+      .from('stores')
+      .select('platform_fee_percent')
+      .eq('id', storeId)
+      .maybeSingle();
+
+    const platformFeeRate = Number(storeRow?.platform_fee_percent ?? 10) / 100;
+    const commissionBase = orderTotal * (1 - platformFeeRate);
+
+    let commissionAmount = 0;
     if (settings.commission_type === 'percentage') {
-      commissionAmount = orderTotal * (settings.commission_rate / 100);
+      commissionAmount = commissionBase * (settings.commission_rate / 100);
     } else if (settings.commission_type === 'fixed') {
       commissionAmount = settings.fixed_commission_amount || 0;
     }
@@ -267,7 +288,7 @@ export const createAffiliateCommission = async (
         store_id: storeId,
         order_id: orderId,
         order_total: orderTotal,
-        commission_base: orderTotal,
+        commission_base: commissionBase,
         commission_rate: settings.commission_rate,
         commission_type: settings.commission_type,
         commission_amount: commissionAmount,
@@ -297,22 +318,9 @@ export const createAffiliateCommission = async (
     logger.log('Affiliate commission created', { commissionId: commission.id, orderId });
 
     return { success: true, commission_id: commission.id };
-  } catch ( _error: unknown) {
+  } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Erreur inconnue';
     logger.error('Error in createAffiliateCommission', { error: errorMessage });
     return { success: false, error: errorMessage };
   }
 };
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/lib/checkout-order-items.ts
+++ b/src/lib/checkout-order-items.ts
@@ -5,6 +5,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import type { CartItem } from '@/types/cart';
+import { validateCheckoutCart } from '@/lib/checkout/cart-validation';
 
 function cartMetadata(item: CartItem): Record<string, unknown> {
   if (item.metadata && typeof item.metadata === 'object' && !Array.isArray(item.metadata)) {
@@ -98,18 +99,16 @@ export async function buildOrderItemRows(
   orderId: string,
   items: CartItem[]
 ): Promise<OrderItemInsertRow[]> {
-  const serviceItems = items.filter(i => i.product_type === 'service');
-  if (serviceItems.length > 0) {
-    throw new Error(
-      'Les services se réservent depuis la page du service, pas via le panier. Retirez-les du panier pour continuer.'
-    );
+  const validation = validateCheckoutCart(items);
+  if (!validation.canCheckout) {
+    throw new Error(validation.message ?? 'Panier incompatible avec le checkout unifié');
   }
 
-  const rows = buildOrderItemRowsSync(orderId, items);
+  const rows = buildOrderItemRowsSync(orderId, validation.checkoutItems);
 
   await Promise.all(
     rows.map(async (row, index) => {
-      const item = items[index];
+      const item = validation.checkoutItems[index];
       if (item.product_type === 'physical' && !row.physical_product_id) {
         const { data } = await supabase
           .from('physical_products')

--- a/src/lib/checkout-shipping.ts
+++ b/src/lib/checkout-shipping.ts
@@ -6,6 +6,8 @@
 import type { CartItem } from '@/types/cart';
 import { calculateArtistShipping } from '@/lib/shipping/artist-shipping';
 import { fetchCheapestFedexShippingCost } from '@/lib/shipping/fedex-rates-client';
+import { resolveStoreZoneShippingAmount } from '@/lib/checkout/shipping-zones';
+import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
 
 export interface CheckoutShippingInput {
@@ -81,6 +83,49 @@ async function resolvePhysicalShippingAmount(
 ): Promise<number> {
   const country = address.country;
   const postalCode = address.postal_code?.trim();
+
+  const subtotal = items.reduce(
+    (sum, item) => sum + (item.unit_price - (item.discount_amount || 0)) * item.quantity,
+    0
+  );
+
+  const productIds = [...new Set(items.map(i => i.product_id))];
+  const { data: products } = await supabase
+    .from('products')
+    .select('id, store_id')
+    .in('id', productIds);
+
+  const storeByProduct = new Map((products ?? []).map(p => [p.id, p.store_id]));
+  const byStore = new Map<string, CartItem[]>();
+  for (const item of items) {
+    const storeId = storeByProduct.get(item.product_id);
+    if (!storeId) continue;
+    const list = byStore.get(storeId) ?? [];
+    list.push(item);
+    byStore.set(storeId, list);
+  }
+
+  let zoneTotal = 0;
+  let zoneApplied = false;
+  for (const [storeId, storeItems] of byStore) {
+    const storeSubtotal = storeItems.reduce(
+      (sum, item) => sum + (item.unit_price - (item.discount_amount || 0)) * item.quantity,
+      0
+    );
+    const zoneAmount = await resolveStoreZoneShippingAmount(
+      storeId,
+      storeItems,
+      address,
+      storeSubtotal
+    );
+    if (zoneAmount != null) {
+      zoneTotal += zoneAmount;
+      zoneApplied = true;
+    }
+  }
+  if (zoneApplied) {
+    return zoneTotal;
+  }
 
   if (postalCode && country.length >= 2) {
     try {

--- a/src/lib/checkout/__tests__/cart-validation.test.ts
+++ b/src/lib/checkout/__tests__/cart-validation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { validateCheckoutCart } from '@/lib/checkout/cart-validation';
+import type { CartItem } from '@/types/cart';
+
+function item(overrides: Partial<CartItem> & Pick<CartItem, 'product_type'>): CartItem {
+  return {
+    id: 'item-1',
+    product_id: 'prod-1',
+    store_id: 'store-1',
+    product_type: overrides.product_type,
+    name: 'Test',
+    quantity: 1,
+    unit_price: 1000,
+    ...overrides,
+  } as CartItem;
+}
+
+describe('validateCheckoutCart', () => {
+  it('allows physical-only cart', () => {
+    const result = validateCheckoutCart([item({ product_type: 'physical' })]);
+    expect(result.canCheckout).toBe(true);
+    expect(result.hasMixedWithService).toBe(false);
+  });
+
+  it('blocks service-only cart', () => {
+    const result = validateCheckoutCart([item({ product_type: 'service' })]);
+    expect(result.canCheckout).toBe(false);
+    expect(result.serviceOnly).toBe(true);
+  });
+
+  it('allows mixed cart when services have booking metadata', () => {
+    const result = validateCheckoutCart([
+      item({ product_type: 'digital' }),
+      item({
+        product_type: 'service',
+        metadata: { booking_id: 'bk-1', scheduled_at: '2026-06-10T10:00:00Z' },
+      }),
+    ]);
+    expect(result.canCheckout).toBe(true);
+    expect(result.hasMixedWithService).toBe(true);
+  });
+
+  it('blocks mixed cart when service lacks booking', () => {
+    const result = validateCheckoutCart([
+      item({ product_type: 'physical' }),
+      item({ product_type: 'service' }),
+    ]);
+    expect(result.canCheckout).toBe(false);
+    expect(result.checkoutItems).toHaveLength(1);
+  });
+});

--- a/src/lib/checkout/__tests__/taxes.test.ts
+++ b/src/lib/checkout/__tests__/taxes.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { calculateCheckoutTaxes } from '@/lib/checkout/taxes';
+
+const rpcMock = vi.fn();
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpcMock(...args),
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('calculateCheckoutTaxes', () => {
+  beforeEach(() => {
+    rpcMock.mockReset();
+  });
+
+  it('returns zero tax when RPC fails (no 18% fallback)', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'rpc missing' } });
+
+    const result = await calculateCheckoutTaxes({
+      subtotal: 10000,
+      shippingAmount: 500,
+      countryCode: 'BF',
+      items: [],
+    });
+
+    expect(result.tax_amount).toBe(0);
+    expect(result.total_with_tax).toBe(10500);
+  });
+
+  it('uses RPC breakdown when available', async () => {
+    rpcMock.mockResolvedValue({
+      data: {
+        tax_amount: 1800,
+        tax_breakdown: [{ type: 'vat', name: 'TVA', rate: 18, amount: 1800 }],
+        subtotal: 10000,
+        shipping_amount: 500,
+        total_with_tax: 12300,
+      },
+      error: null,
+    });
+
+    const result = await calculateCheckoutTaxes({
+      subtotal: 10000,
+      shippingAmount: 500,
+      countryCode: 'BF',
+      storeId: 'store-1',
+      items: [{ product_type: 'physical' } as never],
+    });
+
+    expect(result.tax_amount).toBe(1800);
+    expect(result.total_with_tax).toBe(12300);
+    expect(rpcMock).toHaveBeenCalledWith(
+      'calculate_taxes_pre_order',
+      expect.objectContaining({ p_subtotal: 10000, p_country_code: 'BF' })
+    );
+  });
+});

--- a/src/lib/checkout/cart-validation.ts
+++ b/src/lib/checkout/cart-validation.ts
@@ -1,0 +1,65 @@
+/**
+ * Validation panier avant checkout unifié.
+ */
+
+import type { CartItem } from '@/types/cart';
+
+export interface CheckoutCartValidation {
+  canCheckout: boolean;
+  checkoutItems: CartItem[];
+  serviceOnly: boolean;
+  hasMixedWithService: boolean;
+  message?: string;
+}
+
+function hasServiceBookingMeta(item: CartItem): boolean {
+  const meta = item.metadata;
+  if (!meta || typeof meta !== 'object') return false;
+  return Boolean(
+    meta.booking_id || meta.scheduled_at || meta.service_booking_id || meta.booking_date
+  );
+}
+
+export function validateCheckoutCart(items: CartItem[]): CheckoutCartValidation {
+  const serviceItems = items.filter(i => i.product_type === 'service');
+  const nonServiceItems = items.filter(i => i.product_type !== 'service');
+
+  if (serviceItems.length === 0) {
+    return {
+      canCheckout: true,
+      checkoutItems: items,
+      serviceOnly: false,
+      hasMixedWithService: false,
+    };
+  }
+
+  if (nonServiceItems.length === 0) {
+    return {
+      canCheckout: false,
+      checkoutItems: [],
+      serviceOnly: true,
+      hasMixedWithService: false,
+      message:
+        'Les services se réservent depuis la fiche du service (créneau et prestataire), pas via le panier général.',
+    };
+  }
+
+  const bookedServices = serviceItems.filter(hasServiceBookingMeta);
+  if (bookedServices.length === serviceItems.length) {
+    return {
+      canCheckout: true,
+      checkoutItems: items,
+      serviceOnly: false,
+      hasMixedWithService: true,
+    };
+  }
+
+  return {
+    canCheckout: false,
+    checkoutItems: nonServiceItems,
+    serviceOnly: false,
+    hasMixedWithService: true,
+    message:
+      'Votre panier contient des services sans réservation. Finalisez la réservation sur chaque fiche service, ou retirez les services pour payer les autres articles.',
+  };
+}

--- a/src/lib/checkout/promotion.ts
+++ b/src/lib/checkout/promotion.ts
@@ -1,0 +1,86 @@
+/**
+ * Validation promotions checkout (product_promotions + validate_unified_promotion).
+ */
+
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+
+export interface ValidatedPromotion {
+  promotionId: string;
+  code: string;
+  discountAmount: number;
+  orderTotalBefore: number;
+  orderTotalAfter: number;
+}
+
+export async function validateCheckoutPromotion(params: {
+  code: string;
+  storeId: string;
+  productIds: string[];
+  orderAmount: number;
+  customerId?: string | null;
+  isFirstOrder?: boolean;
+}): Promise<{ valid: true; promotion: ValidatedPromotion } | { valid: false; message: string }> {
+  const normalized = params.code.trim().toUpperCase();
+  if (!normalized) {
+    return { valid: false, message: 'Code promo requis' };
+  }
+
+  let categoryIds: string[] = [];
+  if (params.productIds.length > 0) {
+    const { data: products } = await supabase
+      .from('products')
+      .select('category_id')
+      .in('id', params.productIds);
+    categoryIds = [
+      ...new Set(
+        (products ?? []).map(p => p.category_id).filter((id): id is string => Boolean(id))
+      ),
+    ];
+  }
+
+  const { data, error } = await supabase.rpc('validate_unified_promotion', {
+    p_code: normalized,
+    p_store_id: params.storeId,
+    p_product_ids: params.productIds.length > 0 ? params.productIds : null,
+    p_category_ids: categoryIds.length > 0 ? categoryIds : null,
+    p_collection_ids: null,
+    p_order_amount: params.orderAmount,
+    p_customer_id: params.customerId ?? null,
+    p_is_first_order: params.isFirstOrder ?? false,
+  });
+
+  if (error) {
+    logger.error('validate_unified_promotion failed', { error, code: normalized });
+    return { valid: false, message: error.message || 'Validation impossible' };
+  }
+
+  const row = data as {
+    valid?: boolean;
+    error_message?: string;
+    promotion_id?: string;
+    code?: string;
+    discount_amount?: number;
+    order_total_before?: number;
+    order_total_after?: number;
+  } | null;
+
+  if (!row?.valid || !row.promotion_id) {
+    return {
+      valid: false,
+      message: row?.error_message || 'Code promo invalide ou expiré',
+    };
+  }
+
+  const discountAmount = Number(row.discount_amount ?? 0);
+  return {
+    valid: true,
+    promotion: {
+      promotionId: row.promotion_id,
+      code: row.code ?? normalized,
+      discountAmount,
+      orderTotalBefore: Number(row.order_total_before ?? params.orderAmount),
+      orderTotalAfter: Number(row.order_total_after ?? params.orderAmount - discountAmount),
+    },
+  };
+}

--- a/src/lib/checkout/shipping-zones.ts
+++ b/src/lib/checkout/shipping-zones.ts
@@ -1,0 +1,79 @@
+/**
+ * Frais de port depuis shipping_zones / shipping_rates (vendeur).
+ */
+
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+import type { CartItem } from '@/types/cart';
+import type { CheckoutShippingInput } from '@/lib/checkout-shipping';
+
+export async function resolveStoreZoneShippingAmount(
+  storeId: string,
+  items: CartItem[],
+  address: CheckoutShippingInput,
+  orderSubtotal: number
+): Promise<number | null> {
+  const country = address.country?.trim().toUpperCase();
+  if (!country) return null;
+
+  const productIds = items.map(i => i.product_id);
+  const { data: physicalRows } = await supabase
+    .from('physical_products')
+    .select('product_id, free_shipping')
+    .in('product_id', productIds);
+
+  if (physicalRows?.length && physicalRows.every(p => p.free_shipping)) {
+    return 0;
+  }
+
+  const { data: store } = await supabase
+    .from('stores')
+    .select('free_shipping_threshold')
+    .eq('id', storeId)
+    .maybeSingle();
+
+  const threshold = Number(store?.free_shipping_threshold ?? 0);
+  if (threshold > 0 && orderSubtotal >= threshold) {
+    return 0;
+  }
+
+  const { data: zones } = await supabase
+    .from('shipping_zones')
+    .select('id, countries')
+    .eq('store_id', storeId)
+    .eq('is_active', true);
+
+  if (!zones?.length) return null;
+
+  const matchingZoneIds = zones
+    .filter(z => {
+      const countries = (z.countries ?? []).map((c: string) => c.toUpperCase());
+      return countries.length === 0 || countries.includes(country);
+    })
+    .map(z => z.id);
+
+  if (matchingZoneIds.length === 0) return null;
+
+  const { data: rates } = await supabase
+    .from('shipping_rates')
+    .select('price, min_order_amount, max_order_amount, is_active')
+    .eq('store_id', storeId)
+    .eq('is_active', true)
+    .in('zone_id', matchingZoneIds);
+
+  if (!rates?.length) return null;
+
+  const eligible = rates.filter(r => {
+    const min = r.min_order_amount != null ? Number(r.min_order_amount) : null;
+    const max = r.max_order_amount != null ? Number(r.max_order_amount) : null;
+    if (min != null && orderSubtotal < min) return false;
+    if (max != null && orderSubtotal > max) return false;
+    return true;
+  });
+
+  if (!eligible.length) return null;
+
+  const cheapest = Math.min(...eligible.map(r => Number(r.price ?? 0)));
+  logger.debug('Store zone shipping applied', { storeId, country, amount: cheapest });
+  return Math.max(0, Math.round(cheapest));
+}

--- a/src/lib/checkout/taxes.ts
+++ b/src/lib/checkout/taxes.ts
@@ -1,0 +1,93 @@
+/**
+ * Calcul taxes checkout — pas de TVA 18 % en dur si le RPC échoue.
+ */
+
+import { supabase } from '@/integrations/supabase/client';
+import { logger } from '@/lib/logger';
+import type { CartItem } from '@/types/cart';
+
+export interface TaxBreakdownLine {
+  type: string;
+  name: string;
+  rate: number;
+  amount: number;
+  applies_to_shipping?: boolean;
+  tax_inclusive?: boolean;
+  is_default?: boolean;
+}
+
+export interface CheckoutTaxResult {
+  tax_amount: number;
+  tax_breakdown: TaxBreakdownLine[];
+  subtotal: number;
+  shipping_amount: number;
+  total_with_tax: number;
+}
+
+const ZERO_TAX: CheckoutTaxResult = {
+  tax_amount: 0,
+  tax_breakdown: [],
+  subtotal: 0,
+  shipping_amount: 0,
+  total_with_tax: 0,
+};
+
+export async function calculateCheckoutTaxes(params: {
+  subtotal: number;
+  shippingAmount: number;
+  countryCode: string;
+  stateProvince?: string | null;
+  storeId?: string | null;
+  items: CartItem[];
+}): Promise<CheckoutTaxResult> {
+  const { subtotal, shippingAmount, countryCode, stateProvince, storeId, items } = params;
+
+  if (!countryCode || subtotal <= 0) {
+    return {
+      ...ZERO_TAX,
+      subtotal,
+      shipping_amount: shippingAmount,
+      total_with_tax: subtotal + shippingAmount,
+    };
+  }
+
+  const productTypes = Array.from(new Set(items.map(i => i.product_type)));
+
+  const { data, error } = await supabase.rpc('calculate_taxes_pre_order', {
+    p_subtotal: subtotal,
+    p_shipping_amount: shippingAmount,
+    p_country_code: countryCode,
+    p_state_province: stateProvince ?? null,
+    p_store_id: storeId ?? null,
+    p_product_types: productTypes.length > 0 ? productTypes : null,
+  });
+
+  if (error || data == null) {
+    logger.warn(
+      'calculate_taxes_pre_order unavailable — taxes à 0 (configurer tax_configurations)',
+      {
+        error: error?.message,
+        countryCode,
+        storeId,
+      }
+    );
+    return {
+      tax_amount: 0,
+      tax_breakdown: [],
+      subtotal,
+      shipping_amount: shippingAmount,
+      total_with_tax: subtotal + shippingAmount,
+    };
+  }
+
+  const row = data as CheckoutTaxResult;
+  return {
+    tax_amount: Number(row.tax_amount ?? 0),
+    tax_breakdown: Array.isArray(row.tax_breakdown) ? row.tax_breakdown : [],
+    subtotal: Number(row.subtotal ?? subtotal),
+    shipping_amount: Number(row.shipping_amount ?? shippingAmount),
+    total_with_tax: Number(
+      row.total_with_tax ?? subtotal + shippingAmount + Number(row.tax_amount ?? 0)
+    ),
+  };
+}

--- a/src/lib/orders/__tests__/affiliation-commission-base.test.ts
+++ b/src/lib/orders/__tests__/affiliation-commission-base.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+/** Miroir logique affiliation-tracking / SQL : base = orderTotal * (1 - platformFeeRate) */
+function affiliateCommissionBase(orderTotal: number, platformFeePercent: number): number {
+  return orderTotal * (1 - platformFeePercent / 100);
+}
+
+describe('affiliate commission base', () => {
+  it('uses 90% of order when platform fee is 10%', () => {
+    expect(affiliateCommissionBase(100_000, 10)).toBe(90_000);
+  });
+
+  it('uses custom store platform fee', () => {
+    expect(affiliateCommissionBase(10_000, 15)).toBe(8_500);
+  });
+});

--- a/src/lib/payment-service.ts
+++ b/src/lib/payment-service.ts
@@ -135,15 +135,23 @@ export const verifyTransactionStatus = async (
   transactionId: string,
   provider?: PaymentProvider
 ) => {
-  if (!provider) {
-    const { supabase } = await import('@/integrations/supabase/client');
-    const { data: transaction } = await supabase
-      .from('transactions')
-      .select('payment_provider')
-      .eq('id', transactionId)
-      .single();
+  const { supabase } = await import('@/integrations/supabase/client');
+  const { data: transaction } = await supabase
+    .from('transactions')
+    .select('id, status, payment_provider, moneroo_transaction_id')
+    .eq('id', transactionId)
+    .single();
 
-    provider = (transaction?.payment_provider as PaymentProvider) || 'moneroo';
+  const resolvedProvider =
+    provider ?? (transaction?.payment_provider as PaymentProvider) ?? 'moneroo';
+
+  const connectProviders = ['stripe_connect', 'paypal_commerce', 'paypal'];
+  if (connectProviders.includes(resolvedProvider)) {
+    return transaction ?? { id: transactionId, status: 'unknown' };
+  }
+
+  if (!transaction?.moneroo_transaction_id) {
+    return transaction ?? { id: transactionId, status: 'unknown' };
   }
 
   return verifyMonerooTransaction(transactionId);

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -42,6 +42,8 @@ import { isTaxCalculationResult } from '@/pages/checkout/cart/checkout-types';
 import { validateShippingForm } from '@/pages/checkout/cart/checkout-validation';
 import { buildOrderItemRows } from '@/lib/checkout-order-items';
 import { resolveCheckoutShippingAmount } from '@/lib/checkout-shipping';
+import { calculateCheckoutTaxes } from '@/lib/checkout/taxes';
+import { validateCheckoutCart } from '@/lib/checkout/cart-validation';
 import { reserveArtistLimitedEditionsForCart } from '@/lib/artist-edition-reservation';
 import {
   cartHasPhysicalItems,
@@ -75,21 +77,18 @@ export default function Checkout() {
   const { items, summary, isLoading: cartLoading } = useCart();
   const [isProcessing, setIsProcessing] = useState(false);
 
-  const hasServiceInCart = useMemo(
-    () => items.some(item => item.product_type === 'service'),
-    [items]
-  );
+  const checkoutCartValidation = useMemo(() => validateCheckoutCart(items), [items]);
+  const hasServiceInCart = !checkoutCartValidation.canCheckout;
 
   useEffect(() => {
-    if (hasServiceInCart) {
+    if (!checkoutCartValidation.canCheckout && checkoutCartValidation.message) {
       toast({
-        title: 'Réservation requise',
-        description:
-          'Les services ne passent pas par le panier. Ouvrez la page du service pour choisir un créneau.',
+        title: 'Panier à ajuster',
+        description: checkoutCartValidation.message,
         variant: 'destructive',
       });
     }
-  }, [hasServiceInCart, toast]);
+  }, [checkoutCartValidation.canCheckout, checkoutCartValidation.message, toast]);
 
   // State pour la carte cadeau
   const [appliedGiftCard, setAppliedGiftCard] = useState<AppliedGiftCard | null>(null);
@@ -420,40 +419,14 @@ export default function Checkout() {
         return null;
       }
 
-      const productTypes = Array.from(new Set(items.map(item => item.product_type)));
-
-      const { data, error } = await supabase.rpc('calculate_taxes_pre_order' as never, {
-        p_subtotal: subtotalAfterDiscounts,
-        p_shipping_amount: shippingAmount,
-        p_country_code: formData.country,
-        p_state_province: formData.state || null,
-        p_store_id: storeId || null,
-        p_product_types: productTypes.length > 0 ? productTypes : null,
+      return calculateCheckoutTaxes({
+        subtotal: subtotalAfterDiscounts,
+        shippingAmount,
+        countryCode: formData.country,
+        stateProvince: formData.state || null,
+        storeId: storeId || null,
+        items,
       });
-
-      if (error) {
-        logger.error('Error calculating taxes', { error });
-        // Fallback sur taux par défaut en cas d'erreur
-        return {
-          tax_amount: subtotalAfterDiscounts * 0.18,
-          tax_breakdown: [
-            {
-              type: 'VAT',
-              name: 'TVA',
-              rate: 18,
-              amount: subtotalAfterDiscounts * 0.18,
-              applies_to_shipping: false,
-              tax_inclusive: false,
-              is_default: true,
-            },
-          ],
-          subtotal: subtotalAfterDiscounts,
-          shipping_amount: shippingAmount,
-          total_with_tax: subtotalAfterDiscounts + shippingAmount + subtotalAfterDiscounts * 0.18,
-        };
-      }
-
-      return data;
     },
     enabled: !!formData.country && subtotalAfterDiscounts > 0,
     staleTime: 30000, // Cache pendant 30 secondes
@@ -462,9 +435,8 @@ export default function Checkout() {
   // 5. Calcul des taxes via RPC (utilise les configurations de la base de données)
   const taxAmount = useMemo(() => {
     if (isTaxCalculationResult(taxCalculation)) return Number(taxCalculation.tax_amount);
-    // Fallback si pas encore chargé ou erreur
-    return Math.max(0, subtotalAfterDiscounts * 0.18);
-  }, [taxCalculation, subtotalAfterDiscounts]);
+    return 0;
+  }, [taxCalculation]);
 
   // Breakdown des taxes pour affichage détaillé
   const taxBreakdown = useMemo(() => {
@@ -968,11 +940,12 @@ export default function Checkout() {
       return;
     }
 
-    if (hasServiceInCart) {
+    if (!checkoutCartValidation.canCheckout) {
       toast({
-        title: 'Réservation requise',
+        title: 'Panier à ajuster',
         description:
-          'Les services ne passent pas par le panier. Retirez-les du panier pour continuer.',
+          checkoutCartValidation.message ??
+          'Certains articles ne peuvent pas être payés via ce checkout.',
         variant: 'destructive',
       });
       return;

--- a/src/pages/digital/DigitalProductDetail.tsx
+++ b/src/pages/digital/DigitalProductDetail.tsx
@@ -63,6 +63,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { logger } from '@/lib/logger';
 import { useAddToComparison } from './DigitalProductsCompare';
 import { FileVersionManager, FileMetadataEditor } from '@/components/digital/files';
+import CouponInput from '@/components/checkout/CouponInput';
 
 interface DigitalProductDetailParams {
   productId: string;
@@ -85,6 +86,9 @@ export default function DigitalProductDetail() {
   const { toast } = useToast();
   const { user } = useAuth();
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [appliedCouponId, setAppliedCouponId] = useState<string | null>(null);
+  const [appliedCouponCode, setAppliedCouponCode] = useState<string | null>(null);
+  const [appliedDiscountAmount, setAppliedDiscountAmount] = useState<number | null>(null);
 
   // Fetch digital product with all relations
   const { data: digitalProduct, isLoading, error } = useDigitalProduct(productId || '');
@@ -201,6 +205,9 @@ export default function DigitalProductDetail() {
               : 'unlimited',
         maxActivations:
           digitalProduct.license_type === 'multi' ? digitalProduct.max_licenses : undefined,
+        couponCode: appliedCouponCode ?? undefined,
+        couponDiscountAmount: appliedDiscountAmount ?? undefined,
+        promotionId: appliedCouponId ?? undefined,
       });
 
       if (result.checkoutUrl) {
@@ -219,8 +226,9 @@ export default function DigitalProductDetail() {
       } else {
         throw new Error('URL de paiement non disponible');
       }
-    } catch (_error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+    } catch (purchaseError: unknown) {
+      const errorMessage =
+        purchaseError instanceof Error ? purchaseError.message : String(purchaseError);
       logger.error('Error initiating purchase', {
         error: errorMessage,
         digitalProductId: digitalProduct.id,
@@ -437,30 +445,53 @@ export default function DigitalProductDetail() {
                     </CardContent>
                   </Card>
                 ) : (
-                  <Button
-                    size="lg"
-                    className="w-full sm:w-auto sm:max-w-[min(100%,16rem)] sm:self-start px-6 sm:px-8 rounded-full font-semibold shadow-md hover:shadow-lg"
-                    onClick={handlePurchase}
-                    disabled={
-                      isPurchasing ||
-                      isCreatingOrder ||
-                      !digitalProduct ||
-                      !user ||
-                      !product.is_active
-                    }
-                  >
-                    {isPurchasing || isCreatingOrder ? (
-                      <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        Traitement...
-                      </>
-                    ) : (
-                      <>
-                        <Lock className="h-4 w-4 mr-2" />
-                        Acheter maintenant
-                      </>
+                  <>
+                    {product?.store_id && (
+                      <CouponInput
+                        storeId={product.store_id}
+                        productId={product.id}
+                        customerId={user?.id}
+                        orderAmount={Number(product.promotional_price ?? product.price ?? 0)}
+                        onApply={(promotionId, discountAmount, code) => {
+                          setAppliedCouponId(promotionId);
+                          setAppliedDiscountAmount(discountAmount);
+                          setAppliedCouponCode(code);
+                        }}
+                        onRemove={() => {
+                          setAppliedCouponId(null);
+                          setAppliedDiscountAmount(null);
+                          setAppliedCouponCode(null);
+                        }}
+                        appliedCouponId={appliedCouponId}
+                        appliedCouponCode={appliedCouponCode}
+                        appliedDiscountAmount={appliedDiscountAmount}
+                      />
                     )}
-                  </Button>
+                    <Button
+                      size="lg"
+                      className="w-full sm:w-auto sm:max-w-[min(100%,16rem)] sm:self-start px-6 sm:px-8 rounded-full font-semibold shadow-md hover:shadow-lg"
+                      onClick={handlePurchase}
+                      disabled={
+                        isPurchasing ||
+                        isCreatingOrder ||
+                        !digitalProduct ||
+                        !user ||
+                        !product.is_active
+                      }
+                    >
+                      {isPurchasing || isCreatingOrder ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Traitement...
+                        </>
+                      ) : (
+                        <>
+                          <Lock className="h-4 w-4 mr-2" />
+                          Acheter maintenant
+                        </>
+                      )}
+                    </Button>
+                  </>
                 )}
 
                 {/* Actions supplémentaires */}

--- a/supabase/functions/_shared/apply-payment-refund.ts
+++ b/supabase/functions/_shared/apply-payment-refund.ts
@@ -70,6 +70,13 @@ export async function applyPaymentRefund(
       .from('orders')
       .update({ payment_status: 'refunded', updated_at: now })
       .eq('id', transaction.order_id);
+
+    const { error: revokeError } = await supabase.rpc('revoke_digital_access_for_order', {
+      p_order_id: transaction.order_id,
+    });
+    if (revokeError) {
+      console.error('revoke_digital_access_for_order failed:', revokeError);
+    }
   }
 
   await supabase.from('transaction_logs').insert({

--- a/supabase/functions/moneroo-webhook/index.ts
+++ b/supabase/functions/moneroo-webhook/index.ts
@@ -437,6 +437,7 @@ serve(async req => {
                 plan_id: plan.id,
                 status: 'active',
                 billing_cycle: 'monthly',
+                mrr_amount: Number(plan.monthly_price ?? 0),
                 current_period_start: now.toISOString(),
                 current_period_end: periodEnd.toISOString(),
                 trial_ends_at: null,

--- a/supabase/functions/validate-file-upload/index.ts
+++ b/supabase/functions/validate-file-upload/index.ts
@@ -27,7 +27,7 @@ function resolveCorsOrigin(originHeader: string | null): string {
 function buildCorsHeaders(originHeader: string | null) {
   return {
     'Access-Control-Allow-Origin': resolveCorsOrigin(originHeader),
-    'Vary': 'Origin',
+    Vary: 'Origin',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
     'Access-Control-Max-Age': '86400',
@@ -287,6 +287,40 @@ serve(async req => {
       status: 204,
       headers: corsHeaders,
     });
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    return new Response(
+      JSON.stringify({
+        isValid: false,
+        error: 'Authentification requise',
+        securityLevel: 'danger',
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 401 }
+    );
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (supabaseUrl && supabaseAnonKey) {
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({
+          isValid: false,
+          error: 'Session invalide',
+          securityLevel: 'danger',
+        }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 401 }
+      );
+    }
   }
 
   try {

--- a/supabase/migrations/20250603140000__audit_p1_security_refunds_downloads.sql
+++ b/supabase/migrations/20250603140000__audit_p1_security_refunds_downloads.sql
@@ -1,0 +1,151 @@
+-- Audit P1 : tokens téléchargement sécurisés, révocation accès digital au remboursement
+
+-- =========================================================
+-- generate_download_token : exiger achat payé si customer_id fourni
+-- =========================================================
+
+CREATE OR REPLACE FUNCTION public.generate_download_token(
+  p_product_id UUID,
+  p_file_url TEXT,
+  p_customer_id UUID DEFAULT NULL,
+  p_license_id UUID DEFAULT NULL,
+  p_expires_hours INTEGER DEFAULT 1
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_token TEXT;
+  v_products_id UUID;
+BEGIN
+  SELECT p.id INTO v_products_id
+  FROM public.products p
+  WHERE p.id = p_product_id
+  LIMIT 1;
+
+  IF v_products_id IS NULL THEN
+    SELECT dp.product_id INTO v_products_id
+    FROM public.digital_products dp
+    WHERE dp.id = p_product_id
+    LIMIT 1;
+  END IF;
+
+  IF v_products_id IS NULL THEN
+    RAISE EXCEPTION 'PRODUCT_NOT_FOUND';
+  END IF;
+
+  IF p_customer_id IS NOT NULL THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.order_items oi
+      INNER JOIN public.orders o ON o.id = oi.order_id
+      WHERE oi.product_id = v_products_id
+        AND o.customer_id = p_customer_id
+        AND o.payment_status = 'paid'
+        AND public.is_order_paid_for_revenue(o.status, o.payment_status)
+    ) AND NOT EXISTS (
+      SELECT 1
+      FROM public.digital_licenses dl
+      INNER JOIN public.digital_products dp ON dp.id = dl.digital_product_id
+      WHERE dp.product_id = v_products_id
+        AND dl.status IN ('active', 'pending')
+        AND dl.order_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM public.orders o
+          WHERE o.id = dl.order_id
+            AND o.customer_id = p_customer_id
+            AND o.payment_status = 'paid'
+            AND public.is_order_paid_for_revenue(o.status, o.payment_status)
+        )
+    ) THEN
+      RAISE EXCEPTION 'DOWNLOAD_ACCESS_DENIED';
+    END IF;
+  END IF;
+
+  v_token := encode(gen_random_bytes(32), 'base64');
+  v_token := replace(v_token, '/', '_');
+  v_token := replace(v_token, '+', '-');
+
+  INSERT INTO public.download_tokens (
+    product_id,
+    customer_id,
+    license_id,
+    token,
+    file_url,
+    expires_at
+  ) VALUES (
+    v_products_id,
+    p_customer_id,
+    p_license_id,
+    v_token,
+    p_file_url,
+    now() + (p_expires_hours || ' hours')::interval
+  );
+
+  RETURN v_token;
+END;
+$$;
+
+-- =========================================================
+-- Révocation accès digital (licences + tokens) sur remboursement
+-- =========================================================
+
+CREATE OR REPLACE FUNCTION public.revoke_digital_access_for_order(p_order_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.digital_licenses
+  SET
+    status = 'revoked',
+    updated_at = now()
+  WHERE order_id = p_order_id
+    AND status IN ('active', 'pending');
+
+  UPDATE public.download_tokens dt
+  SET expires_at = now()
+  FROM public.order_items oi
+  INNER JOIN public.digital_products dp ON dp.id = oi.digital_product_id
+  WHERE oi.order_id = p_order_id
+    AND dt.product_id = dp.product_id
+    AND dt.expires_at > now();
+
+  UPDATE public.customer_downloads
+  SET expires_at = now()
+  WHERE order_id = p_order_id
+    AND (expires_at IS NULL OR expires_at > now());
+END;
+$$;
+
+COMMENT ON FUNCTION public.revoke_digital_access_for_order IS
+  'Révoque licences et tokens de téléchargement après remboursement commande.';
+
+CREATE OR REPLACE FUNCTION public.trigger_revoke_digital_access_on_refund()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+    AND NEW.payment_status = 'refunded'
+    AND OLD.payment_status IS DISTINCT FROM 'refunded' THEN
+    PERFORM public.revoke_digital_access_for_order(NEW.id);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS revoke_digital_access_on_order_refund ON public.orders;
+CREATE TRIGGER revoke_digital_access_on_order_refund
+  AFTER UPDATE OF payment_status ON public.orders
+  FOR EACH ROW
+  WHEN (
+    NEW.payment_status = 'refunded'
+    AND OLD.payment_status IS DISTINCT FROM 'refunded'
+  )
+  EXECUTE FUNCTION public.trigger_revoke_digital_access_on_refund();

--- a/supabase/migrations/20250603150000__audit_p2_checkout_rls_subscriptions.sql
+++ b/supabase/migrations/20250603150000__audit_p2_checkout_rls_subscriptions.sql
@@ -1,0 +1,139 @@
+-- Audit P2 : RLS fichiers digitaux, cycle de vie abonnements physiques (plateforme)
+
+BEGIN;
+
+-- =========================================================
+-- digital_product_files : retirer accès public SELECT
+-- =========================================================
+
+DROP POLICY IF EXISTS "Digital files viewable by everyone" ON public.digital_product_files;
+
+DROP POLICY IF EXISTS "Users view purchased files" ON public.digital_product_files;
+CREATE POLICY "Users view purchased files"
+  ON public.digital_product_files
+  FOR SELECT
+  TO authenticated
+  USING (
+    is_preview = TRUE
+    OR requires_purchase = FALSE
+    OR EXISTS (
+      SELECT 1
+      FROM public.digital_licenses dl
+      LEFT JOIN public.orders o ON o.id = dl.order_id
+      WHERE dl.digital_product_id = digital_product_files.digital_product_id
+        AND dl.status IN ('active', 'pending')
+        AND dl.user_id = auth.uid()
+        AND (
+          o.id IS NULL
+          OR (
+            o.payment_status = 'paid'
+            AND public.is_order_paid_for_revenue(o.status, o.payment_status)
+          )
+        )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.order_items oi
+      INNER JOIN public.orders o ON o.id = oi.order_id
+      INNER JOIN public.customers c ON c.id = o.customer_id
+      INNER JOIN public.digital_products dp ON dp.product_id = oi.product_id
+      WHERE dp.id = digital_product_files.digital_product_id
+        AND o.payment_status = 'paid'
+        AND public.is_order_paid_for_revenue(o.status, o.payment_status)
+        AND c.email = (SELECT email FROM auth.users WHERE id = auth.uid())
+    )
+  );
+
+DROP POLICY IF EXISTS "Store owners view digital product files" ON public.digital_product_files;
+CREATE POLICY "Store owners view digital product files"
+  ON public.digital_product_files
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.digital_products dp
+      INNER JOIN public.products p ON p.id = dp.product_id
+      INNER JOIN public.stores s ON s.id = p.store_id
+      WHERE dp.id = digital_product_files.digital_product_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+-- =========================================================
+-- Abonnements boutique physique (store_platform_subscriptions)
+-- =========================================================
+
+CREATE OR REPLACE FUNCTION public.process_store_platform_subscription_lifecycle()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_to_past_due integer := 0;
+  v_to_expired integer := 0;
+BEGIN
+  -- Essai ou période payée terminée → past_due (paiement attendu)
+  UPDATE public.store_platform_subscriptions sps
+  SET
+    status = 'past_due',
+    updated_at = now(),
+    metadata = COALESCE(sps.metadata, '{}'::jsonb) || jsonb_build_object(
+      'lifecycle', 'trial_or_period_ended',
+      'marked_past_due_at', now()
+    )
+  WHERE sps.status IN ('active', 'trialing')
+    AND sps.current_period_end IS NOT NULL
+    AND sps.current_period_end < now()
+    AND (
+      sps.status <> 'trialing'
+      OR sps.trial_ends_at IS NULL
+      OR sps.trial_ends_at < now()
+    );
+  GET DIAGNOSTICS v_to_past_due = ROW_COUNT;
+
+  -- Grace 7 jours après échéance → expired
+  UPDATE public.store_platform_subscriptions sps
+  SET
+    status = 'expired',
+    updated_at = now(),
+    metadata = COALESCE(sps.metadata, '{}'::jsonb) || jsonb_build_object(
+      'lifecycle', 'grace_period_elapsed',
+      'expired_at', now()
+    )
+  WHERE sps.status = 'past_due'
+    AND sps.current_period_end IS NOT NULL
+    AND sps.current_period_end < (now() - interval '7 days');
+  GET DIAGNOSTICS v_to_expired = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'marked_past_due', v_to_past_due,
+    'marked_expired', v_to_expired,
+    'processed_at', now()
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.process_store_platform_subscription_lifecycle() IS
+  'Passe les abonnements physiques plateforme en past_due puis expired (cron quotidien).';
+
+GRANT EXECUTE ON FUNCTION public.process_store_platform_subscription_lifecycle() TO service_role;
+
+-- Cron quotidien si pg_cron disponible
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'process-store-platform-subscriptions') THEN
+      PERFORM cron.unschedule('process-store-platform-subscriptions');
+    END IF;
+
+    PERFORM cron.schedule(
+      'process-store-platform-subscriptions',
+      '15 3 * * *',
+      $cmd$SELECT public.process_store_platform_subscription_lifecycle();$cmd$
+    );
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **P1 securite & remboursements** : migration `20250603140000` (tokens download securises, revocation acces digital au remboursement), `apply-payment-refund`, reecriture `useCustomerDownloads` sur `digital_licenses`, commission affiliés 90 %, JWT obligatoire sur `validate-file-upload`, routage `verifyTransactionStatus` sans forcer Moneroo pour Connect, `mrr_amount` a l activation abonnement physique.
- **P2 checkout & plateforme** : modules `src/lib/checkout` (promotions, taxes sans fallback TVA 18 %, zones shipping vendeur, validation panier mixte services), coupons sur achat digital direct, migration `20250603150000` (RLS `digital_product_files`, cron cycle de vie `store_platform_subscriptions`).

Suite de la PR #15 (P0 deja merge sur `main`). Deux commits : `c482dcd` + `5f909cd`.

## Migrations Supabase (ordre)

1. `20250603140000__audit_p1_security_refunds_downloads.sql`
2. `20250603150000__audit_p2_checkout_rls_subscriptions.sql`

(Prerequis : `20250603120000`, `20100` si besoin, `30000` deja sur `main` via PR #15.)

## Test plan

- [x] `npx vitest run src/lib/checkout/__tests__/` (6 tests)
- [x] `npx vitest run src/lib/orders/__tests__/affiliation-commission-base.test.ts` (1 test)
- [ ] Appliquer migrations `40000` puis `50000` sur staging
- [ ] Remboursement commande digital : acces/licence revoques
- [ ] Checkout panier : taxes via RPC (pas de 18 % en dur si RPC down)
- [ ] Fiche produit digital : code promo puis paiement Moneroo
- [ ] Verifier RLS : fichier non-preview non lisible sans achat
- [ ] Cron / RPC `process_store_platform_subscription_lifecycle` : past_due puis expired apres grace

Made with [Cursor](https://cursor.com)