### PR TITLE
fix(audit): FedEx prod, creneaux services, abonnements produit physique

### DIFF
--- a/src/hooks/shipping/useFedexShipping.ts
+++ b/src/hooks/shipping/useFedexShipping.ts
@@ -1,20 +1,25 @@
 /**
  * FedEx Shipping Hooks
  * Date: 28 octobre 2025
- * 
+ *
  * React Query hooks pour intégration FedEx
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { getFedexService } from '@/services/fedex';
+import { getFedexService, mockFedexService } from '@/services/fedex';
+import { isFedexMockAllowed } from '@/lib/shipping/fedex-policy';
 import type { FedexShipmentRequest, FedexRateRequest } from '@/services/fedex';
 import { useToast } from '@/hooks/use-toast';
 
-const SHIPPING_CARRIER_FIELDS = 'id, store_id, name, code, description, is_active, is_default, credentials, config, supports_tracking, supports_labels, supports_pickup, created_at, updated_at';
-const SHIPMENT_FIELDS = 'id, order_id, carrier_id, store_id, tracking_number, tracking_url, service_type, status, weight_value, shipping_cost, currency, ship_from, ship_to, estimated_delivery, actual_delivery, tracking_events, created_at, updated_at';
-const ORDER_FIELDS = 'id, store_id, customer_id, order_number, subtotal, tax_amount, shipping_amount, discount_amount, total_amount, currency, status, payment_status, created_at, updated_at';
-const SHIPPING_LABEL_FIELDS = 'id, shipment_id, label_format, label_url, label_data, is_printed, printed_at, created_at, updated_at';
+const SHIPPING_CARRIER_FIELDS =
+  'id, store_id, name, code, description, is_active, is_default, credentials, config, supports_tracking, supports_labels, supports_pickup, created_at, updated_at';
+const SHIPMENT_FIELDS =
+  'id, order_id, carrier_id, store_id, tracking_number, tracking_url, service_type, status, weight_value, shipping_cost, currency, ship_from, ship_to, estimated_delivery, actual_delivery, tracking_events, created_at, updated_at';
+const ORDER_FIELDS =
+  'id, store_id, customer_id, order_number, subtotal, tax_amount, shipping_amount, discount_amount, total_amount, currency, status, payment_status, created_at, updated_at';
+const SHIPPING_LABEL_FIELDS =
+  'id, shipment_id, label_format, label_url, label_data, is_printed, printed_at, created_at, updated_at';
 
 // =====================================================
 // TYPES
@@ -86,11 +91,13 @@ export const useShipments = (storeId: string) => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('shipments')
-        .select(`
+        .select(
+          `
           ${SHIPMENT_FIELDS},
           carrier:shipping_carriers(${SHIPPING_CARRIER_FIELDS}),
           order:orders(order_number, total_amount)
-        `)
+        `
+        )
         .eq('store_id', storeId)
         .order('created_at', { ascending: false });
 
@@ -110,12 +117,14 @@ export const useShipment = (shipmentId: string) => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('shipments')
-        .select(`
+        .select(
+          `
           ${SHIPMENT_FIELDS},
           carrier:shipping_carriers(${SHIPPING_CARRIER_FIELDS}),
           order:orders(${ORDER_FIELDS}),
           labels:shipping_labels(${SHIPPING_LABEL_FIELDS})
-        `)
+        `
+        )
         .eq('id', shipmentId)
         .single();
 
@@ -135,11 +144,13 @@ export const useOrderShipments = (orderId: string) => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('shipments')
-        .select(`
+        .select(
+          `
           ${SHIPMENT_FIELDS},
           carrier:shipping_carriers(${SHIPPING_CARRIER_FIELDS}),
           labels:shipping_labels(${SHIPPING_LABEL_FIELDS})
-        `)
+        `
+        )
         .eq('order_id', orderId)
         .order('created_at', { ascending: false });
 
@@ -279,11 +290,12 @@ export const useCreateFedexShipment = () => {
 
       toast({
         title: '✅ Expédition créée',
-        description: 'L\'étiquette d\'expédition a été générée avec succès.',
+        description: "L'étiquette d'expédition a été générée avec succès.",
       });
     },
     onError: (error: unknown) => {
-      const errorMessage = error instanceof Error ? error.message : 'Impossible de créer l\'expédition';
+      const errorMessage =
+        error instanceof Error ? error.message : "Impossible de créer l'expédition";
       toast({
         title: '❌ Erreur',
         description: errorMessage,
@@ -313,9 +325,7 @@ export const useUpdateShipmentTracking = () => {
       }
 
       // 2. Get latest tracking from FedEx
-      const trackingData = await getFedexService().getTracking(
-        shipment.tracking_number
-      );
+      const trackingData = await getFedexService().getTracking(shipment.tracking_number);
 
       if (!trackingData.success) {
         throw new Error('Failed to get tracking info');
@@ -351,7 +361,7 @@ export const useUpdateShipmentTracking = () => {
 
       return updated;
     },
-    onSuccess: (data) => {
+    onSuccess: data => {
       queryClient.invalidateQueries({ queryKey: ['shipment', data.id] });
       queryClient.invalidateQueries({ queryKey: ['shipments', data.store_id] });
       queryClient.invalidateQueries({
@@ -395,11 +405,11 @@ export const useCancelShipment = () => {
       if (error) throw error;
       return updated;
     },
-    onSuccess: (data) => {
+    onSuccess: data => {
       queryClient.invalidateQueries({ queryKey: ['shipments', data.store_id] });
       toast({
         title: '✅ Expédition annulée',
-        description: 'L\'expédition a été annulée avec succès.',
+        description: "L'expédition a été annulée avec succès.",
       });
     },
     onError: (error: unknown) => {
@@ -428,7 +438,12 @@ export const useRequestPickup = () => {
       packageCount: number;
       totalWeight: number;
     }) => {
-      // 1. Request pickup from FedEx
+      if (!isFedexMockAllowed()) {
+        throw new Error(
+          'Collecte FedEx indisponible en production. Configurez FEDEX_API_* ou activez VITE_FEDEX_ALLOW_MOCK en dev.'
+        );
+      }
+
       const pickupResponse = await mockFedexService.requestPickup({
         address: data.address,
         pickupDate: data.pickupDate,
@@ -466,17 +481,17 @@ export const useRequestPickup = () => {
       if (error) throw error;
       return pickup;
     },
-    onSuccess: (data) => {
+    onSuccess: data => {
       queryClient.invalidateQueries({ queryKey: ['pickup-requests', data.store_id] });
       toast({
         title: '✅ Ramassage planifié',
         description: `Confirmation: ${data.confirmation_number}`,
       });
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: '❌ Erreur',
-        description: error.message,
+        description: error instanceof Error ? error.message : 'Erreur inconnue',
         variant: 'destructive',
       });
     },
@@ -487,7 +502,6 @@ export const useRequestPickup = () => {
  * Print shipping label
  */
 export const usePrintLabel = () => {
-  const queryClient = useQueryClient();
   const { toast } = useToast();
 
   return useMutation({
@@ -521,7 +535,7 @@ export const usePrintLabel = () => {
         // Create blob from base64 and download
         const byteCharacters = atob(label.label_data);
         const byteNumbers = new Array(byteCharacters.length);
-        for (let  i= 0; i < byteCharacters.length; i++) {
+        for (let i = 0; i < byteCharacters.length; i++) {
           byteNumbers[i] = byteCharacters.charCodeAt(i);
         }
         const byteArray = new Uint8Array(byteNumbers);
@@ -535,7 +549,7 @@ export const usePrintLabel = () => {
     onSuccess: () => {
       toast({
         title: '🖨️ Étiquette imprimée',
-        description: 'L\'étiquette a été envoyée à l\'impression.',
+        description: "L'étiquette a été envoyée à l'impression.",
       });
     },
     onError: (error: unknown) => {
@@ -548,10 +562,3 @@ export const usePrintLabel = () => {
     },
   });
 };
-
-
-
-
-
-
-

--- a/src/lib/shipping/__tests__/fedex-policy.test.ts
+++ b/src/lib/shipping/__tests__/fedex-policy.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { assertFedexResponseNotMock, FedexUnavailableError } from '../fedex-policy';
+
+describe('fedex-policy', () => {
+  const prevProd = import.meta.env.PROD;
+  const prevAllow = import.meta.env.VITE_FEDEX_ALLOW_MOCK;
+
+  afterEach(() => {
+    import.meta.env.PROD = prevProd;
+    import.meta.env.VITE_FEDEX_ALLOW_MOCK = prevAllow;
+  });
+
+  it('allows mock in non-prod builds', () => {
+    import.meta.env.PROD = false;
+    import.meta.env.VITE_FEDEX_ALLOW_MOCK = undefined;
+    expect(() => assertFedexResponseNotMock('mock')).not.toThrow();
+  });
+
+  it('rejects mock in prod unless VITE_FEDEX_ALLOW_MOCK=true', () => {
+    import.meta.env.PROD = true;
+    import.meta.env.VITE_FEDEX_ALLOW_MOCK = undefined;
+    expect(() => assertFedexResponseNotMock('mock')).toThrow(FedexUnavailableError);
+  });
+
+  it('allows mock in prod when explicitly opted in', () => {
+    import.meta.env.PROD = true;
+    import.meta.env.VITE_FEDEX_ALLOW_MOCK = 'true';
+    expect(() => assertFedexResponseNotMock('mock')).not.toThrow();
+  });
+});

--- a/src/lib/shipping/fedex-policy.ts
+++ b/src/lib/shipping/fedex-policy.ts
@@ -1,0 +1,25 @@
+/**
+ * Politique FedEx côté client : pas de mock transparent en build production.
+ */
+
+export class FedexUnavailableError extends Error {
+  constructor(message = 'FedEx indisponible — tarif forfaitaire appliqué') {
+    super(message);
+    this.name = 'FedexUnavailableError';
+  }
+}
+
+export function isFedexMockAllowed(): boolean {
+  const explicit = import.meta.env.VITE_FEDEX_ALLOW_MOCK;
+  if (explicit === 'true') return true;
+  if (explicit === 'false') return false;
+  return !import.meta.env.PROD;
+}
+
+export function assertFedexResponseNotMock(source?: string): void {
+  if (!isFedexMockAllowed() && source === 'mock') {
+    throw new FedexUnavailableError(
+      'Les tarifs FedEx simulés sont désactivés en production. Configurez les clés API ou les zones vendeur.'
+    );
+  }
+}

--- a/src/lib/shipping/fedex-rates-client.ts
+++ b/src/lib/shipping/fedex-rates-client.ts
@@ -4,6 +4,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
+import { assertFedexResponseNotMock } from '@/lib/shipping/fedex-policy';
 
 export interface FedexRatesAddress {
   country: string;
@@ -41,6 +42,8 @@ export async function fetchFedexRatesViaEdge(params: {
   if (!data?.rates?.length) {
     throw new Error('Aucun tarif FedEx retourné');
   }
+
+  assertFedexResponseNotMock(data.source);
 
   return data;
 }

--- a/src/lib/shipping/fedex-track-client.ts
+++ b/src/lib/shipping/fedex-track-client.ts
@@ -4,6 +4,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/lib/logger';
+import { assertFedexResponseNotMock } from '@/lib/shipping/fedex-policy';
 import type { FedexTrackingResponse } from '@/services/fedex/mockFedexService';
 
 export interface FedexTrackEdgeResponse extends FedexTrackingResponse {
@@ -25,6 +26,8 @@ export async function fetchFedexTrackingViaEdge(
   if (!data?.success || !data.tracking_number) {
     throw new Error('Réponse FedEx track invalide');
   }
+
+  assertFedexResponseNotMock(data.source);
 
   const { source: _source, ...tracking } = data;
   return tracking;

--- a/src/pages/service/BookingsManagement.tsx
+++ b/src/pages/service/BookingsManagement.tsx
@@ -285,15 +285,20 @@ export default function BookingsManagement() {
     start_time: string;
     end_time: string;
     is_active: boolean | null;
-    product_id: string;
-    products: { name: string } | null;
+    service_product_id: string;
+    service_products: {
+      product_id: string;
+      products: { name: string; store_id: string } | null;
+    } | null;
   };
 
   const { data: availabilities } = useQuery<ServiceAvailabilityRow[]>({
-    queryKey: ['service-availabilities'],
+    queryKey: ['service-availabilities', store?.id],
+    enabled: Boolean(store?.id),
     queryFn: async () => {
+      const storeId = store!.id;
       const { data, error } = await supabase
-        .from('service_availability')
+        .from('service_availability_slots')
         .select(
           `
           id,
@@ -301,14 +306,18 @@ export default function BookingsManagement() {
           start_time,
           end_time,
           is_active,
-          product_id,
-          products ( name )
+          service_product_id,
+          service_products!inner (
+            product_id,
+            products!inner ( name, store_id )
+          )
         `
         )
-        .eq('is_active', true);
+        .eq('is_active', true)
+        .eq('service_products.products.store_id', storeId);
 
       if (error) {
-        logger.error('Error fetching availabilities', { error: error.message });
+        logger.error('Error fetching availabilities', { error: error.message, storeId });
         throw error;
       }
       return (data ?? []) as ServiceAvailabilityRow[];
@@ -388,7 +397,7 @@ export default function BookingsManagement() {
             if (!isBooked && start > now) {
               bookingEvents.push({
                 id: `availability-${availability.id}-${format(currentDate, 'yyyy-MM-dd')}`,
-                title: `Disponible - ${availability.products?.name || 'Service'}`,
+                title: `Disponible - ${availability.service_products?.products?.name || 'Service'}`,
                 start,
                 end,
                 type: 'available',

--- a/src/services/fedex/FedexService.ts
+++ b/src/services/fedex/FedexService.ts
@@ -3,6 +3,7 @@ import { logger } from '@/lib/logger';
 import { createFedexShipmentViaEdge } from '@/lib/shipping/fedex-ship-client';
 import { cancelFedexShipmentViaEdge } from '@/lib/shipping/fedex-cancel-client';
 import { fetchFedexTrackingViaEdge } from '@/lib/shipping/fedex-track-client';
+import { isFedexMockAllowed, FedexUnavailableError } from '@/lib/shipping/fedex-policy';
 import {
   mockFedexService,
   type FedexRateRequest,
@@ -59,10 +60,13 @@ export class FedexService {
           }));
         }
       } catch (edgeError) {
-        logger.warn('FedEx edge rates fallback to mock', { edgeError });
+        logger.warn('FedEx edge rates failed', { edgeError });
       }
     }
 
+    if (!isFedexMockAllowed()) {
+      throw new FedexUnavailableError();
+    }
     return mockFedexService.getRates(request);
   }
 
@@ -77,10 +81,13 @@ export class FedexService {
       try {
         return await createFedexShipmentViaEdge(request);
       } catch (edgeError) {
-        logger.warn('FedEx edge ship fallback to mock', { edgeError });
+        logger.warn('FedEx edge ship failed', { edgeError });
       }
     }
 
+    if (!isFedexMockAllowed()) {
+      throw new FedexUnavailableError('FedEx expédition indisponible en production');
+    }
     return mockFedexService.createShipment(request);
   }
 
@@ -89,10 +96,13 @@ export class FedexService {
       try {
         return await fetchFedexTrackingViaEdge(trackingNumber.trim());
       } catch (edgeError) {
-        logger.warn('FedEx edge track fallback to mock', { edgeError, trackingNumber });
+        logger.warn('FedEx edge track failed', { edgeError, trackingNumber });
       }
     }
 
+    if (!isFedexMockAllowed()) {
+      throw new FedexUnavailableError('Suivi FedEx indisponible en production');
+    }
     return mockFedexService.getTracking(trackingNumber);
   }
 
@@ -101,10 +111,13 @@ export class FedexService {
       try {
         return await cancelFedexShipmentViaEdge(trackingNumber.trim());
       } catch (edgeError) {
-        logger.warn('FedEx edge cancel fallback to mock', { edgeError, trackingNumber });
+        logger.warn('FedEx edge cancel failed', { edgeError, trackingNumber });
       }
     }
 
+    if (!isFedexMockAllowed()) {
+      throw new FedexUnavailableError('Annulation FedEx indisponible en production');
+    }
     return mockFedexService.cancelShipment(trackingNumber);
   }
 }

--- a/supabase/functions/_shared/fedex-policy.ts
+++ b/supabase/functions/_shared/fedex-policy.ts
@@ -1,0 +1,35 @@
+/**
+ * Politique FedEx Edge : pas de réponses mock en production sauf opt-in explicite.
+ */
+
+export function hasFedexApiCredentials(): boolean {
+  return Boolean(
+    Deno.env.get('FEDEX_API_KEY') &&
+    Deno.env.get('FEDEX_API_SECRET') &&
+    Deno.env.get('FEDEX_ACCOUNT_NUMBER')
+  );
+}
+
+export function hasFedexTrackCredentials(): boolean {
+  return Boolean(Deno.env.get('FEDEX_API_KEY') && Deno.env.get('FEDEX_API_SECRET'));
+}
+
+/** Mock autorisé en dev/staging ; en prod uniquement si FEDEX_ALLOW_MOCK=true */
+export function allowFedexMockResponses(): boolean {
+  const explicit = (Deno.env.get('FEDEX_ALLOW_MOCK') || '').toLowerCase();
+  if (explicit === 'true') return true;
+  if (explicit === 'false') return false;
+
+  const env = (
+    Deno.env.get('ENVIRONMENT') ||
+    Deno.env.get('VERCEL_ENV') ||
+    Deno.env.get('NODE_ENV') ||
+    ''
+  ).toLowerCase();
+
+  return env !== 'production';
+}
+
+export function fedexMockDisabledError(): Error {
+  return new Error('FEDEX_NOT_CONFIGURED');
+}

--- a/supabase/functions/fedex-cancel/index.ts
+++ b/supabase/functions/fedex-cancel/index.ts
@@ -4,6 +4,11 @@
  */
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import {
+  allowFedexMockResponses,
+  fedexMockDisabledError,
+  hasFedexApiCredentials,
+} from '../_shared/fedex-policy.ts';
 
 const defaultAllowedOrigin = Deno.env.get('SITE_URL') || 'https://www.emarzona.com';
 const allowedOrigins = (Deno.env.get('ALLOWED_ORIGINS') || defaultAllowedOrigin)
@@ -80,6 +85,9 @@ async function cancelFedExShipment(trackingNumber: string): Promise<CancelRespon
   const testMode = (Deno.env.get('FEDEX_TEST_MODE') || 'true').toLowerCase() !== 'false';
 
   if (!apiKey || !apiSecret || !accountNumber) {
+    if (!allowFedexMockResponses()) {
+      throw fedexMockDisabledError();
+    }
     return mockCancel(trackingNumber);
   }
 
@@ -103,7 +111,10 @@ async function cancelFedExShipment(trackingNumber: string): Promise<CancelRespon
 
   if (!response.ok) {
     const err = await response.text();
-    console.warn('FedEx cancel API failed, using mock:', err);
+    console.warn('FedEx cancel API failed:', err);
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_FAILED');
+    }
     return mockCancel(trackingNumber);
   }
 
@@ -115,6 +126,9 @@ async function cancelFedExShipment(trackingNumber: string): Promise<CancelRespon
     output.success === true;
 
   if (!cancelled && !output.message) {
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_EMPTY');
+    }
     return mockCancel(trackingNumber);
   }
 
@@ -152,15 +166,9 @@ serve(async req => {
     }
 
     const trackingNumber = body.tracking_number.trim();
-    const hasCredentials = Boolean(
-      Deno.env.get('FEDEX_API_KEY') &&
-      Deno.env.get('FEDEX_API_SECRET') &&
-      Deno.env.get('FEDEX_ACCOUNT_NUMBER')
-    );
-
     const result = await cancelFedExShipment(trackingNumber);
 
-    if (!hasCredentials && result.source !== 'mock') {
+    if (!hasFedexApiCredentials() && result.source !== 'mock') {
       result.source = 'mock';
     }
 
@@ -171,8 +179,10 @@ serve(async req => {
   } catch (error) {
     console.error('fedex-cancel error:', error);
     const message = error instanceof Error ? error.message : 'Erreur FedEx cancel';
+    const status =
+      message === 'FEDEX_NOT_CONFIGURED' ? 503 : message.startsWith('FEDEX_API') ? 502 : 500;
     return new Response(JSON.stringify({ error: message }), {
-      status: 500,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }

--- a/supabase/functions/fedex-rates/index.ts
+++ b/supabase/functions/fedex-rates/index.ts
@@ -4,6 +4,11 @@
  */
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import {
+  allowFedexMockResponses,
+  fedexMockDisabledError,
+  hasFedexApiCredentials,
+} from '../_shared/fedex-policy.ts';
 
 const defaultAllowedOrigin = Deno.env.get('SITE_URL') || 'https://www.emarzona.com';
 const allowedOrigins = (Deno.env.get('ALLOWED_ORIGINS') || defaultAllowedOrigin)
@@ -102,6 +107,9 @@ async function fetchFedExRates(body: RateRequestBody): Promise<RateQuote[]> {
   const testMode = (Deno.env.get('FEDEX_TEST_MODE') || 'true').toLowerCase() !== 'false';
 
   if (!apiKey || !apiSecret || !accountNumber) {
+    if (!allowFedexMockResponses()) {
+      throw fedexMockDisabledError();
+    }
     return mockRates(body.weight_kg, body.ship_to.country);
   }
 
@@ -155,7 +163,10 @@ async function fetchFedExRates(body: RateRequestBody): Promise<RateQuote[]> {
 
   if (!response.ok) {
     const err = await response.text();
-    console.warn('FedEx rates API failed, using mock:', err);
+    console.warn('FedEx rates API failed:', err);
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_FAILED');
+    }
     return mockRates(body.weight_kg, body.ship_to.country);
   }
 
@@ -163,6 +174,9 @@ async function fetchFedExRates(body: RateRequestBody): Promise<RateQuote[]> {
   const rateReplyDetails = data?.output?.rateReplyDetails || [];
 
   if (!Array.isArray(rateReplyDetails) || rateReplyDetails.length === 0) {
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_EMPTY');
+    }
     return mockRates(body.weight_kg, body.ship_to.country);
   }
 
@@ -210,26 +224,24 @@ serve(async req => {
     const weightKg =
       typeof body.weight_kg === 'number' && body.weight_kg > 0 ? body.weight_kg : 0.5;
 
-    const hasCredentials = Boolean(
-      Deno.env.get('FEDEX_API_KEY') &&
-      Deno.env.get('FEDEX_API_SECRET') &&
-      Deno.env.get('FEDEX_ACCOUNT_NUMBER')
-    );
-
+    const hasCredentials = hasFedexApiCredentials();
     const rates = await fetchFedExRates({ ...body, weight_kg: weightKg });
+    const source = hasCredentials ? 'fedex_api' : 'mock';
 
     return new Response(
       JSON.stringify({
         rates,
-        source: hasCredentials ? 'fedex_api' : 'mock',
+        source,
       }),
       { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (error) {
     console.error('fedex-rates error:', error);
     const message = error instanceof Error ? error.message : 'Erreur FedEx';
+    const status =
+      message === 'FEDEX_NOT_CONFIGURED' ? 503 : message.startsWith('FEDEX_API') ? 502 : 500;
     return new Response(JSON.stringify({ error: message }), {
-      status: 500,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }

--- a/supabase/functions/fedex-ship/index.ts
+++ b/supabase/functions/fedex-ship/index.ts
@@ -4,6 +4,11 @@
  */
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import {
+  allowFedexMockResponses,
+  fedexMockDisabledError,
+  hasFedexApiCredentials,
+} from '../_shared/fedex-policy.ts';
 
 const defaultAllowedOrigin = Deno.env.get('SITE_URL') || 'https://www.emarzona.com';
 const allowedOrigins = (Deno.env.get('ALLOWED_ORIGINS') || defaultAllowedOrigin)
@@ -120,6 +125,9 @@ async function createFedExShipment(body: ShipRequestBody): Promise<ShipResponse>
   const testMode = (Deno.env.get('FEDEX_TEST_MODE') || 'true').toLowerCase() !== 'false';
 
   if (!apiKey || !apiSecret || !accountNumber) {
+    if (!allowFedexMockResponses()) {
+      throw fedexMockDisabledError();
+    }
     return mockShipment(body);
   }
 
@@ -199,7 +207,10 @@ async function createFedExShipment(body: ShipRequestBody): Promise<ShipResponse>
 
   if (!response.ok) {
     const err = await response.text();
-    console.warn('FedEx ship API failed, using mock:', err);
+    console.warn('FedEx ship API failed:', err);
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_FAILED');
+    }
     return mockShipment(body);
   }
 
@@ -215,6 +226,9 @@ async function createFedExShipment(body: ShipRequestBody): Promise<ShipResponse>
   );
 
   if (!trackingNumber) {
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_EMPTY');
+    }
     return mockShipment(body);
   }
 
@@ -284,18 +298,12 @@ serve(async req => {
         ? body.package.weight_kg
         : 0.5;
 
-    const hasCredentials = Boolean(
-      Deno.env.get('FEDEX_API_KEY') &&
-      Deno.env.get('FEDEX_API_SECRET') &&
-      Deno.env.get('FEDEX_ACCOUNT_NUMBER')
-    );
-
     const result = await createFedExShipment({
       ...body,
       package: { ...body.package, weight_kg: weightKg },
     });
 
-    if (!hasCredentials && result.source !== 'mock') {
+    if (!hasFedexApiCredentials() && result.source !== 'mock') {
       result.source = 'mock';
     }
 
@@ -306,8 +314,10 @@ serve(async req => {
   } catch (error) {
     console.error('fedex-ship error:', error);
     const message = error instanceof Error ? error.message : 'Erreur FedEx ship';
+    const status =
+      message === 'FEDEX_NOT_CONFIGURED' ? 503 : message.startsWith('FEDEX_API') ? 502 : 500;
     return new Response(JSON.stringify({ error: message }), {
-      status: 500,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }

--- a/supabase/functions/fedex-track/index.ts
+++ b/supabase/functions/fedex-track/index.ts
@@ -4,6 +4,11 @@
  */
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import {
+  allowFedexMockResponses,
+  fedexMockDisabledError,
+  hasFedexTrackCredentials,
+} from '../_shared/fedex-policy.ts';
 
 const defaultAllowedOrigin = Deno.env.get('SITE_URL') || 'https://www.emarzona.com';
 const allowedOrigins = (Deno.env.get('ALLOWED_ORIGINS') || defaultAllowedOrigin)
@@ -135,6 +140,9 @@ async function fetchFedExTracking(trackingNumber: string): Promise<TrackResponse
   const testMode = (Deno.env.get('FEDEX_TEST_MODE') || 'true').toLowerCase() !== 'false';
 
   if (!apiKey || !apiSecret) {
+    if (!allowFedexMockResponses()) {
+      throw fedexMockDisabledError();
+    }
     return mockTracking(trackingNumber);
   }
 
@@ -157,7 +165,10 @@ async function fetchFedExTracking(trackingNumber: string): Promise<TrackResponse
 
   if (!response.ok) {
     const err = await response.text();
-    console.warn('FedEx track API failed, using mock:', err);
+    console.warn('FedEx track API failed:', err);
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_FAILED');
+    }
     return mockTracking(trackingNumber);
   }
 
@@ -202,6 +213,9 @@ async function fetchFedExTracking(trackingNumber: string): Promise<TrackResponse
   }
 
   if (events.length === 0) {
+    if (!allowFedexMockResponses()) {
+      throw new Error('FEDEX_API_EMPTY');
+    }
     return mockTracking(trackingNumber);
   }
 
@@ -245,13 +259,9 @@ serve(async req => {
     }
 
     const trackingNumber = body.tracking_number.trim();
-    const hasCredentials = Boolean(
-      Deno.env.get('FEDEX_API_KEY') && Deno.env.get('FEDEX_API_SECRET')
-    );
-
     const result = await fetchFedExTracking(trackingNumber);
 
-    if (!hasCredentials && result.source !== 'mock') {
+    if (!hasFedexTrackCredentials() && result.source !== 'mock') {
       result.source = 'mock';
     }
 
@@ -262,8 +272,10 @@ serve(async req => {
   } catch (error) {
     console.error('fedex-track error:', error);
     const message = error instanceof Error ? error.message : 'Erreur FedEx track';
+    const status =
+      message === 'FEDEX_NOT_CONFIGURED' ? 503 : message.startsWith('FEDEX_API') ? 502 : 500;
     return new Response(JSON.stringify({ error: message }), {
-      status: 500,
+      status,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }

--- a/supabase/migrations/20250603160000__physical_product_subscription_lifecycle.sql
+++ b/supabase/migrations/20250603160000__physical_product_subscription_lifecycle.sql
@@ -1,0 +1,90 @@
+-- Audit P2 : cycle de vie abonnements produits physiques (client → produit)
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.process_physical_product_subscription_lifecycle()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_to_past_due integer := 0;
+  v_to_expired integer := 0;
+  v_to_cancelled integer := 0;
+BEGIN
+  UPDATE public.physical_product_subscriptions pps
+  SET
+    status = 'past_due',
+    failed_payment_attempts = COALESCE(pps.failed_payment_attempts, 0) + 1,
+    updated_at = now(),
+    metadata = COALESCE(pps.metadata, '{}'::jsonb) || jsonb_build_object(
+      'lifecycle', 'period_ended',
+      'marked_past_due_at', now()
+    )
+  WHERE pps.status IN ('active', 'trialing')
+    AND pps.current_period_end < now()
+    AND (
+      pps.status <> 'trialing'
+      OR pps.trial_end IS NULL
+      OR pps.trial_end < now()
+    )
+    AND COALESCE(pps.cancel_at_period_end, false) = false;
+  GET DIAGNOSTICS v_to_past_due = ROW_COUNT;
+
+  UPDATE public.physical_product_subscriptions pps
+  SET
+    status = 'cancelled',
+    cancelled_at = COALESCE(pps.cancelled_at, now()),
+    updated_at = now(),
+    metadata = COALESCE(pps.metadata, '{}'::jsonb) || jsonb_build_object(
+      'lifecycle', 'cancel_at_period_end',
+      'cancelled_at', now()
+    )
+  WHERE pps.status IN ('active', 'trialing')
+    AND pps.current_period_end < now()
+    AND pps.cancel_at_period_end = true;
+  GET DIAGNOSTICS v_to_cancelled = ROW_COUNT;
+
+  UPDATE public.physical_product_subscriptions pps
+  SET
+    status = 'expired',
+    updated_at = now(),
+    metadata = COALESCE(pps.metadata, '{}'::jsonb) || jsonb_build_object(
+      'lifecycle', 'grace_elapsed',
+      'expired_at', now()
+    )
+  WHERE pps.status = 'past_due'
+    AND pps.current_period_end < (now() - interval '7 days');
+  GET DIAGNOSTICS v_to_expired = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'marked_past_due', v_to_past_due,
+    'marked_cancelled', v_to_cancelled,
+    'marked_expired', v_to_expired,
+    'processed_at', now()
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.process_physical_product_subscription_lifecycle() IS
+  'Passe les abonnements produits physiques en past_due, cancelled (fin de période) ou expired.';
+
+GRANT EXECUTE ON FUNCTION public.process_physical_product_subscription_lifecycle() TO service_role;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'process-physical-product-subscriptions') THEN
+      PERFORM cron.unschedule('process-physical-product-subscriptions');
+    END IF;
+
+    PERFORM cron.schedule(
+      'process-physical-product-subscriptions',
+      '30 3 * * *',
+      $cmd$SELECT public.process_physical_product_subscription_lifecycle();$cmd$
+    );
+  END IF;
+END $$;
+
+COMMIT;

--- a/tests/e2e/course-enrollment-flow.spec.ts
+++ b/tests/e2e/course-enrollment-flow.spec.ts
@@ -102,6 +102,14 @@ test.describe('Flux inscription aux cours', () => {
     expect(page.url()).toMatch(/\/checkout|moneroo/);
   });
 
+  test('page checkout répond sans erreur serveur', async ({ page }) => {
+    const response = await gotoApp(page, '/checkout');
+    expect(response?.status()).toBeLessThan(500);
+    await expect(page.locator('body')).toBeVisible();
+    const html = await page.content();
+    expect(html.toLowerCase()).not.toContain('internal server error');
+  });
+
   test('route /learn/:slug répond sans crash', async ({ page }) => {
     const slug = process.env.E2E_COURSE_SLUG ?? 'test-course-slug';
     const response = await gotoApp(page, `/learn/${slug}`);


### PR DESCRIPTION
## Summary

- **P0 FedEx (R2)** : en production, plus de fallback mock transparent (Edge + client). Politique via `FEDEX_ALLOW_MOCK` / `ENVIRONMENT=production` (serveur) et `VITE_FEDEX_ALLOW_MOCK` / `import.meta.env.PROD` (client). Checkout conserve le forfait flat si FedEx indisponible.
- **P1 services (R3)** : `BookingsManagement` interroge `service_availability_slots` (avec filtre boutique) au lieu de la table inexistante `service_availability`.
- **P2 abonnements** : migration `20250603160000` — `process_physical_product_subscription_lifecycle()` + cron pg_cron quotidien.
- **QA** : tests `fedex-policy` + E2E checkout page smoke sur flux cours.

## Migrations Supabase

Apres merge des PR #15/#16 deja sur main :

\\\
20250603160000__physical_product_subscription_lifecycle.sql
\\\

## Configuration prod FedEx

Secrets Supabase : `FEDEX_API_KEY`, `FEDEX_API_SECRET`, `FEDEX_ACCOUNT_NUMBER`  
Optionnel staging : `FEDEX_ALLOW_MOCK=true`  
Ne pas definir `FEDEX_ALLOW_MOCK` en production (defaut = pas de mock).

## Test plan

- [x] \
px vitest run src/lib/shipping/__tests__/fedex-policy.test.ts\
- [x] \
px vitest run src/lib/checkout/__tests__/ src/lib/__tests__/checkout-shipping.test.ts\
- [ ] Deploy Edge functions \edex-rates\, \edex-ship\, \edex-track\, \edex-cancel\
- [ ] Calendrier reservations vendeur : creneaux disponibles visibles
- [ ] Checkout physique sans cles FedEx : tarif forfait (pas mock affiche comme API)

Made with [Cursor](https://cursor.com)