### PR TITLE
feat(payments): orchestration V2 + fulfillment unifie multi-PSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ VITE_SUPABASE_ANON_KEY=sb_publishable_votre_cle
 
 # Vérification : npm run verify:supabase-keys
 # Doc déploiement : docs/DEPLOIEMENT_FRONT_SUPABASE_KEYS.md
+
+# Orchestration paiements multi-PSP (Stripe Connect, PayPal Commerce, Moneroo)
+# VITE_PAYMENT_ORCHESTRATION_V2=true
+# Actif automatiquement sur previews Vercel si non défini (voir src/lib/payments/feature-flags.ts)

--- a/src/components/checkout/PaymentProviderSelector.tsx
+++ b/src/components/checkout/PaymentProviderSelector.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import {
   useStorePaymentOptions,
   rpcProviderToCheckout,
+  checkoutProviderToRpc,
   type CheckoutPaymentProvider,
 } from '@/hooks/payments/useStorePaymentOptions';
 import { isPaymentOrchestrationV2Enabled } from '@/lib/payments/feature-flags';
@@ -130,10 +131,14 @@ export function PaymentProviderSelector({
         const pref = data?.payment_provider_preference;
         if (!pref) return;
 
-        const checkoutPref =
+        const checkoutPref: CheckoutPaymentProvider =
           pref === 'moneroo' || pref === 'moneroo_platform'
             ? 'moneroo'
-            : (pref as CheckoutPaymentProvider);
+            : pref === 'stripe_connect' ||
+                pref === 'paypal_commerce' ||
+                pref === 'flutterwave_connect'
+              ? pref
+              : 'moneroo';
 
         const match = providers.find(p => p.value === checkoutPref);
         if (match) onChange(match.value);
@@ -148,15 +153,15 @@ export function PaymentProviderSelector({
   const handleProviderChange = async (provider: CheckoutPaymentProvider) => {
     onChange(provider);
 
-    if (user && (provider === 'moneroo' || provider === 'stripe_connect')) {
+    if (user) {
       try {
-        const dbPref = provider === 'moneroo' ? 'moneroo' : 'moneroo';
+        const dbPref = checkoutProviderToRpc(provider);
         await supabase
           .from('profiles')
           .update({ payment_provider_preference: dbPref })
           .eq('user_id', user.id);
       } catch (error) {
-        logger.debug('Could not save payment preference (schema may be moneroo-only)', { error });
+        logger.debug('Could not save payment preference', { error, provider });
       }
     }
   };

--- a/src/lib/payments/__tests__/create-orchestrated-payment.test.ts
+++ b/src/lib/payments/__tests__/create-orchestrated-payment.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../orchestrator/load-connections';
 import { createMonerooPlatformPayment } from '../adapters/moneroo-adapter';
 import { createStripeConnectPayment } from '../adapters/stripe-connect-adapter';
+import { createPayPalCommercePayment } from '../adapters/paypal-commerce-adapter';
 
 const baseConnection = (overrides: Partial<StorePaymentConnection>): StorePaymentConnection => ({
   id: 'conn-1',
@@ -117,5 +118,44 @@ describe('createOrchestratedPayment', () => {
     expect(createMonerooPlatformPayment).toHaveBeenCalledOnce();
     expect(createStripeConnectPayment).not.toHaveBeenCalled();
     expect(result.provider).toBe('moneroo_platform');
+  });
+
+  it('honore preferredProvider via resolve (PayPal si compatible)', async () => {
+    const connections = [
+      baseConnection({ id: 'c-m', provider: 'moneroo_platform' }),
+      baseConnection({
+        id: 'c-p',
+        provider: 'paypal_commerce',
+        external_account_id: 'merchant_1',
+      }),
+      baseConnection({
+        id: 'c-s',
+        provider: 'stripe_connect',
+        capabilities: { card_payments: true },
+      }),
+    ];
+    vi.mocked(loadStorePaymentConnections).mockResolvedValue(connections);
+
+    vi.mocked(createPayPalCommercePayment).mockResolvedValue({
+      success: true,
+      transaction_id: 'tx-p',
+      checkout_url: 'https://paypal.com/checkout',
+      provider: 'paypal_commerce',
+    });
+
+    const result = await createOrchestratedPayment({
+      storeId: 'store-1',
+      orderId: 'order-3',
+      amount: 50,
+      currency: 'USD',
+      description: 'USD order',
+      customerEmail: 'buyer@example.com',
+      preferredProvider: 'paypal_commerce',
+      connections,
+    });
+
+    expect(createPayPalCommercePayment).toHaveBeenCalledOnce();
+    expect(createStripeConnectPayment).not.toHaveBeenCalled();
+    expect(result.provider).toBe('paypal_commerce');
   });
 });

--- a/src/lib/payments/__tests__/feature-flags.test.ts
+++ b/src/lib/payments/__tests__/feature-flags.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { isPaymentOrchestrationV2Enabled } from '../feature-flags';
+
+describe('isPaymentOrchestrationV2Enabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true when VITE_PAYMENT_ORCHESTRATION_V2=true', () => {
+    vi.stubEnv('VITE_PAYMENT_ORCHESTRATION_V2', 'true');
+    expect(isPaymentOrchestrationV2Enabled()).toBe(true);
+  });
+
+  it('returns false when explicitly disabled', () => {
+    vi.stubEnv('VITE_PAYMENT_ORCHESTRATION_V2', 'false');
+    vi.stubEnv('VITE_VERCEL_ENV', 'preview');
+    expect(isPaymentOrchestrationV2Enabled()).toBe(false);
+  });
+
+  it('returns true on Vercel preview when V2 env unset', () => {
+    vi.stubEnv('VITE_VERCEL_ENV', 'preview');
+    expect(isPaymentOrchestrationV2Enabled()).toBe(true);
+  });
+});

--- a/src/lib/payments/__tests__/multi-store-checkout.test.ts
+++ b/src/lib/payments/__tests__/multi-store-checkout.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { validateMultiStorePaymentProvider } from '../multi-store-checkout';
+
+describe('validateMultiStorePaymentProvider', () => {
+  it('allows any provider for single store', () => {
+    expect(
+      validateMultiStorePaymentProvider({
+        storeCount: 1,
+        provider: 'stripe_connect',
+        orchestrationEnabled: true,
+      }).allowed
+    ).toBe(true);
+  });
+
+  it('blocks Stripe on multi-store when orchestration enabled', () => {
+    const result = validateMultiStorePaymentProvider({
+      storeCount: 2,
+      provider: 'stripe_connect',
+      orchestrationEnabled: true,
+    });
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.message).toMatch(/Moneroo/i);
+    }
+  });
+
+  it('allows Moneroo multi-store', () => {
+    expect(
+      validateMultiStorePaymentProvider({
+        storeCount: 3,
+        provider: 'moneroo',
+        orchestrationEnabled: true,
+      }).allowed
+    ).toBe(true);
+  });
+});

--- a/src/lib/payments/feature-flags.ts
+++ b/src/lib/payments/feature-flags.ts
@@ -3,8 +3,24 @@
  */
 
 const TRUE_VALUES = new Set(['true', '1', 'yes']);
+const FALSE_VALUES = new Set(['false', '0', 'no']);
 
+/**
+ * Orchestration multi-PSP (Stripe Connect, PayPal Commerce, Moneroo plateforme).
+ * - `VITE_PAYMENT_ORCHESTRATION_V2=true` : activé partout
+ * - `VITE_PAYMENT_ORCHESTRATION_V2=false` : désactivé (legacy Moneroo seul)
+ * - Non défini + preview Vercel : activé pour QA staging
+ */
 export function isPaymentOrchestrationV2Enabled(): boolean {
   const env = import.meta.env.VITE_PAYMENT_ORCHESTRATION_V2;
-  return env !== undefined && TRUE_VALUES.has(String(env).toLowerCase());
+  if (env !== undefined) {
+    const normalized = String(env).toLowerCase();
+    if (FALSE_VALUES.has(normalized)) return false;
+    return TRUE_VALUES.has(normalized);
+  }
+
+  const vercelEnv = import.meta.env.VITE_VERCEL_ENV;
+  if (vercelEnv === 'preview') return true;
+
+  return false;
 }

--- a/src/lib/payments/multi-store-checkout.ts
+++ b/src/lib/payments/multi-store-checkout.ts
@@ -1,0 +1,36 @@
+/**
+ * Règles checkout panier multi-boutiques × orchestration multi-PSP.
+ */
+
+import type { CheckoutPaymentProvider } from '@/hooks/payments/useStorePaymentOptions';
+
+const CONNECT_PROVIDERS = new Set<CheckoutPaymentProvider>(['stripe_connect', 'paypal_commerce']);
+
+export function isConnectCheckoutProvider(provider: CheckoutPaymentProvider): boolean {
+  return CONNECT_PROVIDERS.has(provider);
+}
+
+/**
+ * Stripe/PayPal Connect ne supportent pas encore un seul checkout multi-boutiques.
+ */
+export function validateMultiStorePaymentProvider(params: {
+  storeCount: number;
+  provider: CheckoutPaymentProvider;
+  orchestrationEnabled: boolean;
+}): { allowed: true } | { allowed: false; message: string } {
+  const { storeCount, provider, orchestrationEnabled } = params;
+
+  if (storeCount <= 1 || !orchestrationEnabled) {
+    return { allowed: true };
+  }
+
+  if (isConnectCheckoutProvider(provider)) {
+    return {
+      allowed: false,
+      message:
+        'Le panier contient plusieurs boutiques : seul Moneroo est disponible pour payer en une fois. Choisissez Moneroo ou retirez des articles pour payer par carte/PayPal boutique par boutique.',
+    };
+  }
+
+  return { allowed: true };
+}

--- a/src/lib/payments/orchestrator/create-payment.ts
+++ b/src/lib/payments/orchestrator/create-payment.ts
@@ -54,19 +54,14 @@ export async function createOrchestratedPayment(
         : loadStoreForcePlatformPayments(request.storeId),
     ]);
 
-    const resolved = request.preferredProvider
-      ? {
-          provider: request.preferredProvider,
-          connectionId: connections.find(c => c.provider === request.preferredProvider)?.id ?? null,
-          reason: 'explicit_preferred',
-        }
-      : resolvePaymentProvider({
-          storeId: request.storeId,
-          amount: request.amount,
-          currency: request.currency ?? 'XOF',
-          connections,
-          forcePlatformPayments: forcePlatform,
-        });
+    const resolved = resolvePaymentProvider({
+      storeId: request.storeId,
+      amount: request.amount,
+      currency: request.currency ?? 'XOF',
+      connections,
+      forcePlatformPayments: forcePlatform,
+      buyerPreferredProvider: request.preferredProvider,
+    });
 
     logger.log('Payment orchestrator resolved provider', {
       storeId: request.storeId,

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -44,6 +44,8 @@ import { buildOrderItemRows } from '@/lib/checkout-order-items';
 import { resolveCheckoutShippingAmount } from '@/lib/checkout-shipping';
 import { calculateCheckoutTaxes } from '@/lib/checkout/taxes';
 import { validateCheckoutCart } from '@/lib/checkout/cart-validation';
+import { isPaymentOrchestrationV2Enabled } from '@/lib/payments/feature-flags';
+import { validateMultiStorePaymentProvider } from '@/lib/payments/multi-store-checkout';
 import { reserveArtistLimitedEditionsForCart } from '@/lib/artist-edition-reservation';
 import {
   cartHasPhysicalItems,
@@ -514,7 +516,7 @@ export default function Checkout() {
     giftCardAmount: number;
     appliedCouponCode: { id: string; discountAmount: number; code: string } | null;
     appliedGiftCard: { id: string; balance: number; code: string } | null;
-    selectedPaymentProvider: 'moneroo';
+    selectedPaymentProvider: PaymentProvider;
   }) => {
     const createdOrders: Array<{
       orderId: string;
@@ -973,7 +975,20 @@ export default function Checkout() {
       if (isMultiStore && storeGroups.size > 1) {
         logger.info('Multi-store checkout detected', { storeCount: storeGroups.size });
 
-        // Implémenter le traitement complet multi-stores
+        const multiStorePaymentCheck = validateMultiStorePaymentProvider({
+          storeCount: storeGroups.size,
+          provider: selectedPaymentProvider,
+          orchestrationEnabled: isPaymentOrchestrationV2Enabled(),
+        });
+        if (!multiStorePaymentCheck.allowed) {
+          toast({
+            title: 'Paiement non disponible',
+            description: multiStorePaymentCheck.message,
+            variant: 'destructive',
+          });
+          return;
+        }
+
         await processMultiStoreCheckout({
           storeGroups,
           formData,

--- a/src/pages/payments/PaymentSuccess.tsx
+++ b/src/pages/payments/PaymentSuccess.tsx
@@ -2,10 +2,23 @@ import { useState, useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { CheckCircle, Download, ShoppingBag, ArrowRight } from 'lucide-react';
+import { CheckCircle, Download, ShoppingBag, ArrowRight, Loader2 } from 'lucide-react';
 import { OneClickUpsell } from '@/components/upsell/OneClickUpsell';
 import { supabase } from '@/integrations/supabase/client';
+import { verifyTransactionStatus } from '@/lib/payment-service';
 import { logger } from '@/lib/logger';
+
+type ConfirmationState = 'loading' | 'confirmed' | 'pending' | 'failed';
+
+function mapUrlProviderToPaymentProvider(
+  provider: string | null
+): 'moneroo' | 'stripe_connect' | 'paypal_commerce' | undefined {
+  if (!provider) return undefined;
+  if (provider === 'stripe' || provider === 'stripe_connect') return 'stripe_connect';
+  if (provider === 'paypal' || provider === 'paypal_commerce') return 'paypal_commerce';
+  if (provider === 'moneroo' || provider === 'moneroo_platform') return 'moneroo';
+  return undefined;
+}
 
 const PaymentSuccess = () => {
   const [searchParams] = useSearchParams();
@@ -13,40 +26,19 @@ const PaymentSuccess = () => {
   const [showUpsell, setShowUpsell] = useState(false);
   const [purchasedProductId, setPurchasedProductId] = useState<string | null>(null);
   const [purchasedProductType, setPurchasedProductType] = useState<string>('digital');
+  const [confirmationState, setConfirmationState] = useState<ConfirmationState>('loading');
 
-  useEffect(() => {
-    const orderId = searchParams.get('order_id');
-    const provider = searchParams.get('provider');
-    const sessionId = searchParams.get('session_id');
+  const orderId = searchParams.get('order_id');
+  const transactionId = searchParams.get('transaction_id');
+  const providerParam = searchParams.get('provider');
+  const sessionId = searchParams.get('session_id');
 
-    if (provider === 'stripe' && sessionId) {
-      logger.log('Stripe checkout success', { sessionId, orderId });
-    }
-    if (provider === 'paypal') {
-      const token = searchParams.get('token');
-      logger.log('PayPal checkout success', { token, orderId });
-    }
-
-    if (orderId) {
-      loadOrderInfo(orderId);
-    }
-
-    // Afficher l'upsell après 2 secondes
-    const timer = setTimeout(() => {
-      if (purchasedProductId) {
-        setShowUpsell(true);
-      }
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [searchParams, purchasedProductId]);
-
-  const loadOrderInfo = async (orderId: string) => {
+  const loadOrderInfo = async (id: string) => {
     try {
       const { data: orderItems } = await supabase
         .from('order_items')
         .select('product_id, product_type')
-        .eq('order_id', orderId)
+        .eq('order_id', id)
         .limit(1)
         .single();
 
@@ -59,21 +51,121 @@ const PaymentSuccess = () => {
     }
   };
 
+  useEffect(() => {
+    if (providerParam === 'stripe' && sessionId) {
+      logger.log('Stripe checkout return', { sessionId, orderId, transactionId });
+    }
+    if (providerParam === 'paypal') {
+      logger.log('PayPal checkout return', {
+        token: searchParams.get('token'),
+        orderId,
+        transactionId,
+      });
+    }
+
+    let cancelled = false;
+
+    const confirmPayment = async () => {
+      try {
+        if (transactionId) {
+          const mappedProvider = mapUrlProviderToPaymentProvider(providerParam);
+          await verifyTransactionStatus(transactionId, mappedProvider);
+        }
+
+        if (orderId) {
+          for (let attempt = 0; attempt < 15; attempt++) {
+            if (cancelled) return;
+
+            const { data: order } = await supabase
+              .from('orders')
+              .select('payment_status, status')
+              .eq('id', orderId)
+              .maybeSingle();
+
+            if (order?.payment_status === 'paid') {
+              setConfirmationState('confirmed');
+              await loadOrderInfo(orderId);
+              return;
+            }
+
+            if (order?.payment_status === 'failed') {
+              setConfirmationState('failed');
+              return;
+            }
+
+            await new Promise(r => setTimeout(r, 2000));
+          }
+
+          setConfirmationState('pending');
+          await loadOrderInfo(orderId);
+          return;
+        }
+
+        setConfirmationState('confirmed');
+      } catch (error) {
+        logger.error('Payment success confirmation error', { error, orderId, transactionId });
+        setConfirmationState('pending');
+        if (orderId) {
+          await loadOrderInfo(orderId);
+        }
+      }
+    };
+
+    void confirmPayment();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [orderId, transactionId, providerParam, sessionId, searchParams]);
+
+  useEffect(() => {
+    if (confirmationState !== 'confirmed' || !purchasedProductId) return;
+
+    const timer = setTimeout(() => setShowUpsell(true), 2000);
+    return () => clearTimeout(timer);
+  }, [confirmationState, purchasedProductId]);
+
+  const title =
+    confirmationState === 'confirmed'
+      ? 'Paiement réussi ! 🎉'
+      : confirmationState === 'pending'
+        ? 'Paiement en cours de confirmation'
+        : confirmationState === 'failed'
+          ? 'Paiement non confirmé'
+          : 'Vérification du paiement…';
+
+  const description =
+    confirmationState === 'confirmed'
+      ? 'Merci pour votre achat ! Votre paiement a été confirmé.'
+      : confirmationState === 'pending'
+        ? 'Votre banque ou PSP finalise encore le paiement. Consultez vos commandes dans quelques instants.'
+        : confirmationState === 'failed'
+          ? "Le paiement n'a pas abouti. Vous pouvez réessayer depuis vos commandes."
+          : 'Nous vérifions le statut auprès du prestataire de paiement…';
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-blue-50 dark:from-gray-900 dark:to-gray-800 p-4">
       <Card className="max-w-2xl w-full">
         <CardContent className="p-8 text-center space-y-6">
           <div className="flex justify-center">
             <div className="h-20 w-20 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center">
-              <CheckCircle className="h-12 w-12 text-green-600" />
+              {confirmationState === 'loading' ? (
+                <Loader2 className="h-12 w-12 text-green-600 animate-spin" />
+              ) : (
+                <CheckCircle
+                  className={`h-12 w-12 ${confirmationState === 'failed' ? 'text-amber-600' : 'text-green-600'}`}
+                />
+              )}
             </div>
           </div>
 
           <div>
-            <h1 className="text-3xl font-bold text-green-600 mb-2">Paiement réussi ! 🎉</h1>
-            <p className="text-lg text-muted-foreground">
-              Merci pour votre achat ! Votre paiement a été confirmé.
-            </p>
+            <h1
+              className={`text-3xl font-bold mb-2 ${confirmationState === 'failed' ? 'text-amber-600' : 'text-green-600'}`}
+            >
+              {title}
+            </h1>
+            <p className="text-lg text-muted-foreground">{description}</p>
           </div>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -104,8 +196,7 @@ const PaymentSuccess = () => {
         </CardContent>
       </Card>
 
-      {/* Upsell Popup */}
-      {purchasedProductId && (
+      {purchasedProductId && confirmationState === 'confirmed' && (
         <OneClickUpsell
           purchasedProductId={purchasedProductId}
           purchasedProductType={purchasedProductType}

--- a/supabase/functions/moneroo-webhook/index.ts
+++ b/supabase/functions/moneroo-webhook/index.ts
@@ -3,11 +3,11 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.58.0';
 import { runPostOrderPaymentFulfillment } from '../_shared/post-order-payment-fulfillment.ts';
 import {
+  completeTransactionAndOrder,
   markWebhookProcessed,
   recordWebhookEvent,
   validateOrderPaymentAmount,
 } from '../_shared/complete-order-payment.ts';
-import { resolvePaidOrderStatusForOrder } from '../_shared/order-status.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': Deno.env.get('SITE_URL') || 'https://www.emarzona.com',
@@ -366,40 +366,35 @@ serve(async req => {
         }
       }
 
-      // Update associated order if exists
-      let order = null;
+      // Commande : même pipeline que Stripe/PayPal (statut paid + fulfillment unifié)
+      let order: Record<string, unknown> | null = null;
       if (transaction.order_id) {
-        const { data: prevOrder } = await supabase
-          .from('orders')
-          .select('payment_status')
-          .eq('id', transaction.order_id)
-          .single();
-        const wasAlreadyPaid = prevOrder?.payment_status === 'paid';
-
-        const paidOrderStatus = await resolvePaidOrderStatusForOrder(
+        const { orderId, alreadyCompleted } = await completeTransactionAndOrder(
           supabase,
-          transaction.order_id
+          transaction.id,
+          {
+            webhookPayload: safePayloadForLogs,
+            paymentProviderUsed: transaction.payment_provider || 'moneroo_platform',
+          }
         );
 
-        const { data: orderData, error: orderError } = await supabase
-          .from('orders')
-          .update({
-            payment_status: 'paid',
-            status: paidOrderStatus,
-            payment_provider_used: transaction.payment_provider || 'moneroo_platform',
-          })
-          .eq('id', transaction.order_id)
-          .select(
-            'id,store_id,order_number,customer_id,total_amount,currency,status,payment_status,created_at,metadata,customer_email,shipping_address,expected_delivery_date,tracking_number,tracking_link'
-          )
-          .single();
+        if (orderId) {
+          if (!alreadyCompleted) {
+            await runPostOrderPaymentFulfillment(supabase, orderId, transaction.id);
+          }
 
-        if (orderError) {
-          console.error('Error updating order:', orderError);
-        } else if (orderData) {
-          order = orderData;
-          if (!wasAlreadyPaid) {
-            await runPostOrderPaymentFulfillment(supabase, orderData.id, transaction.id);
+          const { data: orderData, error: orderError } = await supabase
+            .from('orders')
+            .select(
+              'id,store_id,order_number,customer_id,total_amount,currency,status,payment_status,created_at,metadata,customer_email,shipping_address,expected_delivery_date,tracking_number,tracking_link'
+            )
+            .eq('id', orderId)
+            .single();
+
+          if (orderError) {
+            console.error('Error loading order after payment:', orderError);
+          } else if (orderData) {
+            order = orderData as Record<string, unknown>;
           }
         }
       }

--- a/supabase/functions/paypal-create-order/index.ts
+++ b/supabase/functions/paypal-create-order/index.ts
@@ -98,7 +98,7 @@ serve(async req => {
     }
 
     const successSep = body.successUrl.includes('?') ? '&' : '?';
-    const successWithParams = `${body.successUrl}${successSep}order_id=${body.orderId}&provider=paypal`;
+    const successWithParams = `${body.successUrl}${successSep}order_id=${body.orderId}&transaction_id=${transaction.id}&provider=paypal`;
 
     const paypalOrder = await createPayPalCheckoutOrder({
       amount: body.amount,

--- a/supabase/functions/stripe-create-checkout/index.ts
+++ b/supabase/functions/stripe-create-checkout/index.ts
@@ -107,7 +107,7 @@ serve(async req => {
 
     const params: Record<string, string> = {
       mode: 'payment',
-      success_url: `${body.successUrl}${body.successUrl.includes('?') ? '&' : '?'}session_id={CHECKOUT_SESSION_ID}&order_id=${body.orderId}&provider=stripe`,
+      success_url: `${body.successUrl}${body.successUrl.includes('?') ? '&' : '?'}session_id={CHECKOUT_SESSION_ID}&order_id=${body.orderId}&transaction_id=${transaction.id}&provider=stripe`,
       cancel_url: body.cancelUrl,
       customer_email: body.customerEmail,
       'line_items[0][quantity]': '1',

--- a/tests/e2e/artist-product-workflow.spec.ts
+++ b/tests/e2e/artist-product-workflow.spec.ts
@@ -8,7 +8,11 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { E2E_TEST_CONFIG, gotoApp, loginAs } from './shared/e2e-test-config';
+import { E2E_TEST_CONFIG, gotoApp, loginAs, appLocator } from './shared/e2e-test-config';
+import {
+  openFirstProductCard,
+  openMarketplaceWithOptionalFilter,
+} from './shared/marketplace-discovery';
 
 test.describe('Artist product workflow', () => {
   test.setTimeout(90_000);
@@ -34,25 +38,35 @@ test.describe('Artist product workflow', () => {
     expect(response?.status()).toBeLessThan(500);
     await expect(page.locator('body')).toBeVisible();
 
-    const artistFilter = page.locator(
-      'button:has-text("Artiste"), button:has-text("Œuvre"), button:has-text("Artist"), [data-product-type="artist"]'
-    );
-    if (
-      await artistFilter
-        .first()
-        .isVisible()
-        .catch(() => false)
-    ) {
-      await artistFilter.first().click();
+    const hasProducts = await openMarketplaceWithOptionalFilter(page, 'artist');
+    if (!hasProducts) {
+      test.skip(true, 'Marketplace sans produits');
+      return;
     }
 
-    const card = page.locator('[data-testid="product-card"]').first();
-    if (await card.isVisible().catch(() => false)) {
-      await card.click();
-      await page.waitForURL(/\/(artist|stores)\//, { timeout: 15_000 }).catch(() => undefined);
-      const url = page.url();
-      expect(url.length).toBeGreaterThan(0);
-    }
+    const opened = await openFirstProductCard(page, /\/(artist|stores)\//);
+    expect(opened || page.url().includes('/marketplace')).toBeTruthy();
+  });
+
+  test('artist listing /artists responds without server error', async ({ page }) => {
+    const response = await gotoApp(page, '/artists');
+    expect(response?.status()).toBeLessThan(500);
+    const html = (await page.content()).toLowerCase();
+    expect(html).not.toContain('internal server error');
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('guest add-to-cart CTA on artist detail when E2E_ARTIST_PRODUCT_ID set', async ({
+    page,
+  }) => {
+    const productId = process.env.E2E_ARTIST_PRODUCT_ID;
+    test.skip(!productId, 'Set E2E_ARTIST_PRODUCT_ID');
+
+    await gotoApp(page, `/artist/${productId}`);
+    const cta = appLocator(page).getByRole('button', {
+      name: /acheter|ajouter|panier|buy|commander/i,
+    });
+    await expect(cta.first().or(page.locator('h1'))).toBeVisible({ timeout: 15_000 });
   });
 
   test('artist product detail route responds (optional E2E_ARTIST_PRODUCT_ID)', async ({

--- a/tests/e2e/checkout-multi-psp.spec.ts
+++ b/tests/e2e/checkout-multi-psp.spec.ts
@@ -109,6 +109,25 @@ test.describe('Checkout multi-PSP — acheteur authentifié', () => {
     await loginAs(page, E2E_TEST_CONFIG.buyerEmail, E2E_TEST_CONFIG.buyerPassword);
   });
 
+  test('orchestration V2 : sélection Moneroo visible si plusieurs PSP (smoke)', async ({
+    page,
+  }) => {
+    test.skip(!orchestrationV2, 'Définir VITE_PAYMENT_ORCHESTRATION_V2=true');
+
+    await loginAs(page, E2E_TEST_CONFIG.buyerEmail, E2E_TEST_CONFIG.buyerPassword);
+    await gotoApp(page, '/checkout?productId=00000000-0000-0000-0000-000000000001');
+
+    const monerooRadio = page.locator('#payment-moneroo, [id^="payment-"]').first();
+    await Promise.race([
+      page.getByText(/moyen de paiement/i).waitFor({ timeout: 25_000 }),
+      monerooRadio.waitFor({ timeout: 25_000 }),
+      page.getByText(/aucun moyen de paiement/i).waitFor({ timeout: 25_000 }),
+    ]).catch(() => undefined);
+
+    const html = (await page.content()).toLowerCase();
+    expect(html).not.toContain('internal server error');
+  });
+
   test('checkout authentifié charge sans erreur fatale', async ({ page }) => {
     test.setTimeout(90_000);
     const response = await gotoApp(page, '/checkout');

--- a/tests/e2e/course-enrollment-flow.spec.ts
+++ b/tests/e2e/course-enrollment-flow.spec.ts
@@ -6,7 +6,11 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { E2E_TEST_CONFIG, gotoApp, loginAs } from './shared/e2e-test-config';
+import { E2E_TEST_CONFIG, gotoApp, loginAs, appLocator } from './shared/e2e-test-config';
+import {
+  openFirstProductCard,
+  openMarketplaceWithOptionalFilter,
+} from './shared/marketplace-discovery';
 
 test.describe('Flux inscription aux cours', () => {
   test.setTimeout(90_000);
@@ -14,30 +18,43 @@ test.describe('Flux inscription aux cours', () => {
   test('découverte marketplace et fiche cours', async ({ page }) => {
     await gotoApp(page, '/marketplace');
 
-    const card = page.locator('[data-testid="product-card"]').first();
-    const hasCards = await card.isVisible().catch(() => false);
+    const hasCards = await openMarketplaceWithOptionalFilter(page, 'course');
     if (!hasCards) {
       test.skip(true, 'Aucune carte produit sur marketplace (env vide)');
       return;
     }
 
-    const courseFilter = page.locator(
-      'button:has-text("Cours"), button:has-text("Course"), [data-product-type="course"]'
-    );
-    if (
-      await courseFilter
-        .first()
-        .isVisible()
-        .catch(() => false)
-    ) {
-      await courseFilter.first().click();
+    const onCourse = await openFirstProductCard(page, /\/courses\//);
+    if (!onCourse) {
+      test.skip(true, 'Aucune fiche cours atteinte depuis le marketplace');
+      return;
     }
 
-    await card.click();
-    await page.waitForURL(/\/courses\//, { timeout: 15_000 });
     await expect(page.locator('h1').first()).toBeVisible();
     await expect(
       page.getByRole('button', { name: /inscrire|acheter|s'inscrire|enroll/i }).first()
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('landing /courses catalogue sans erreur serveur', async ({ page }) => {
+    const response = await gotoApp(page, '/courses');
+    expect(response?.status()).toBeLessThan(500);
+    const html = (await page.content()).toLowerCase();
+    expect(html).not.toContain('internal server error');
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('fiche cours directe quand E2E_COURSE_PRODUCT_ID est défini', async ({ page }) => {
+    const productId = process.env.E2E_COURSE_PRODUCT_ID;
+    test.skip(!productId, 'Set E2E_COURSE_PRODUCT_ID pour fiche cours stable');
+
+    const response = await gotoApp(page, `/courses/${productId}`);
+    expect(response?.status()).toBeLessThan(500);
+    await expect(appLocator(page).locator('h1').first()).toBeVisible({ timeout: 15_000 });
+    await expect(
+      appLocator(page)
+        .getByRole('button', { name: /inscrire|acheter|s'inscrire|enroll/i })
+        .first()
     ).toBeVisible({ timeout: 10_000 });
   });
 

--- a/tests/e2e/shared/marketplace-discovery.ts
+++ b/tests/e2e/shared/marketplace-discovery.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers E2E — découverte produits sur le marketplace (cours, artiste, etc.)
+ */
+
+import type { Page } from '@playwright/test';
+import { appLocator } from './e2e-test-config';
+
+export type MarketplaceProductType = 'course' | 'artist' | 'digital' | 'physical' | 'service';
+
+export async function openMarketplaceWithOptionalFilter(
+  page: Page,
+  productType?: MarketplaceProductType
+): Promise<boolean> {
+  const root = appLocator(page);
+  const card = root.locator('[data-testid="product-card"]').first();
+  const hasCard = await card.isVisible().catch(() => false);
+  if (!hasCard) return false;
+
+  if (productType) {
+    const filterByType: Record<MarketplaceProductType, string> = {
+      course: 'button:has-text("Cours"), button:has-text("Course"), [data-product-type="course"]',
+      artist:
+        'button:has-text("Artiste"), button:has-text("Œuvre"), button:has-text("Artist"), [data-product-type="artist"]',
+      digital:
+        'button:has-text("Digital"), button:has-text("Numérique"), [data-product-type="digital"]',
+      physical:
+        'button:has-text("Physique"), button:has-text("Physical"), [data-product-type="physical"]',
+      service: 'button:has-text("Service"), [data-product-type="service"]',
+    };
+    const filter = root.locator(filterByType[productType]);
+    if (
+      await filter
+        .first()
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await filter.first().click();
+    }
+  }
+
+  return true;
+}
+
+export async function openFirstProductCard(page: Page, urlPattern: RegExp): Promise<boolean> {
+  const root = appLocator(page);
+  const card = root.locator('[data-testid="product-card"]').first();
+  if (!(await card.isVisible().catch(() => false))) return false;
+
+  await card.click();
+  await page.waitForURL(urlPattern, { timeout: 15_000 }).catch(() => undefined);
+  return urlPattern.test(page.url());
+}


### PR DESCRIPTION
## Summary

Inclut **PR #18** (orchestration V2 routing, E2E artiste/cours) plus phase 2 R1 :

- **Fulfillment unifie** : \moneroo-webhook\ utilise \completeTransactionAndOrder\ + \unPostOrderPaymentFulfillment\ (meme pipeline que Stripe/PayPal, statuts \completed\/\confirmed\).
- **Multi-store** : blocage explicite Stripe/PayPal Connect sur panier multi-boutiques quand orchestration V2 active (\alidateMultiStorePaymentProvider\).
- **Retour checkout** : \PaymentSuccess\ verifie transaction + poll \orders.payment_status\ ; URLs Stripe/PayPal incluent \	ransaction_id\.
- **Orchestration** (PR #18) : resolve provider via \uyerPreferredProvider\, feature flag preview Vercel, preferences profil PSP corrigees.

## Deploy

- Redeploy Edge : \moneroo-webhook\, \stripe-create-checkout\, \paypal-create-order\
- Frontend : \VITE_PAYMENT_ORCHESTRATION_V2=true\ en prod quand pret

## Test plan

- [x] \
px vitest run src/lib/payments/__tests__/\ (15 tests)
- [ ] Paiement Moneroo : commande digital \completed\ + download
- [ ] Paiement Stripe Connect EUR : \pplication_fee\ + fulfillment artiste/service
- [ ] Panier 2 boutiques + Stripe selectionne : message Moneroo requis
- [ ] \/payment/success?order_id=&transaction_id=&provider=stripe\ : etat confirme ou pending

Made with [Cursor](https://cursor.com)