### PR TITLE
feat(payments): phase 3 remboursements unifies + runbook prod V2

### DIFF
--- a/docs/PAYMENT_ORCHESTRATION_V2_PROD_RUNBOOK.md
+++ b/docs/PAYMENT_ORCHESTRATION_V2_PROD_RUNBOOK.md
@@ -1,0 +1,187 @@
+# Runbook — Activation production Orchestration Paiements V2
+
+**Version** : 1.0 · **Date** : 2026-06-03  
+**Référence consolidation** : PR [#19](https://github.com/payhuk02/emarzona/pull/19) (absorbe #15–#18)  
+**Plans liés** : [PAYMENT_ORCHESTRATION_IMPLEMENTATION_PLAN.md](./PAYMENT_ORCHESTRATION_IMPLEMENTATION_PLAN.md), [STRIPE_CONNECT_SETUP.md](./STRIPE_CONNECT_SETUP.md), [PAYPAL_COMMERCE_SETUP.md](./PAYPAL_COMMERCE_SETUP.md)
+
+---
+
+## 1. Vue d’ensemble
+
+| Rail                   | Rôle                                   | Merchant of record                               |
+| ---------------------- | -------------------------------------- | ------------------------------------------------ |
+| **Moneroo plateforme** | Afrique francophone, XOF, mobile money | Emarzona → reversement wallet                    |
+| **Stripe Connect**     | Cartes internationales EUR/USD/GBP     | Vendeur (destination charge + `application_fee`) |
+| **PayPal Commerce**    | PayPal + cartes via PayPal             | Vendeur (platform fee)                           |
+
+**Feature flag frontend** : `VITE_PAYMENT_ORCHESTRATION_V2=true`  
+**Preview Vercel** : V2 activé automatiquement si la variable n’est pas définie (voir `src/lib/payments/feature-flags.ts`).
+
+---
+
+## 2. Prérequis migrations SQL (ordre)
+
+Appliquer sur **staging puis prod** :
+
+| Ordre | Migration                                                         | Rôle                                                             |
+| ----- | ----------------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1     | `20260523120000__payment_orchestration_v2_foundation.sql`         | Connexions PSP, RPC `get_store_payment_options`, webhooks events |
+| 2     | `20250603120000__fix_order_status_paid_revenue_eligibility.sql`   | Revenus vendeur + statuts paid                                   |
+| 3     | `20250603120100__hotfix_store_earnings_trigger_pg42p17.sql`       | Si échec trigger 42P17                                           |
+| 4     | `20250603130000__affiliate_paid_trigger_and_connect_earnings.sql` | Affiliés au paiement, wallet sans Connect                        |
+| 5     | `20250603140000__audit_p1_security_refunds_downloads.sql`         | Tokens download, révocation digital                              |
+| 6     | `20250603150000__audit_p2_checkout_rls_subscriptions.sql`         | RLS fichiers, cron abo plateforme                                |
+| 7     | `20250603160000__physical_product_subscription_lifecycle.sql`     | Cron abo produit physique                                        |
+
+Vérification :
+
+```bash
+node scripts/verify-payment-v2-remote.mjs
+```
+
+---
+
+## 3. Edge Functions à déployer
+
+```bash
+cd c:\emarzona
+
+# Orchestration checkout
+npx supabase functions deploy stripe-connect-onboard --no-verify-jwt
+npx supabase functions deploy stripe-create-checkout
+npx supabase functions deploy stripe-connect-webhook --no-verify-jwt
+npx supabase functions deploy stripe-refund
+
+npx supabase functions deploy paypal-partner-onboard --no-verify-jwt
+npx supabase functions deploy paypal-create-order
+npx supabase functions deploy paypal-webhook --no-verify-jwt
+npx supabase functions deploy paypal-refund
+
+# Rail plateforme (existant)
+npx supabase functions deploy moneroo-webhook --no-verify-jwt
+npx supabase functions deploy moneroo
+```
+
+---
+
+## 4. Secrets Supabase (prod)
+
+| Secret                                      | PSP        | Obligatoire                         |
+| ------------------------------------------- | ---------- | ----------------------------------- |
+| `STRIPE_SECRET_KEY`                         | Stripe     | Oui si Connect                      |
+| `STRIPE_WEBHOOK_SECRET`                     | Stripe     | Oui                                 |
+| `PAYPAL_CLIENT_ID` / `PAYPAL_CLIENT_SECRET` | PayPal     | Oui si Commerce                     |
+| `PAYPAL_WEBHOOK_ID`                         | PayPal     | Oui                                 |
+| `MONEROO_*`                                 | Moneroo    | Oui (rail principal)                |
+| `SITE_URL`                                  | CORS       | `https://www.emarzona.com`          |
+| `ALLOWED_ORIGINS`                           | CORS       | Domaine prod + admin                |
+| `FEDEX_*`                                   | Shipping   | Prod sans mock (voir runbook FedEx) |
+| `ENVIRONMENT=production`                    | FedEx Edge | Désactive mock shipping             |
+
+**Stripe webhook events** : `checkout.session.completed`, `charge.refunded`, `account.updated`  
+**PayPal webhook events** : capture completed, `PAYMENT.CAPTURE.REFUNDED`, onboarding
+
+---
+
+## 5. Activation frontend (Vercel)
+
+1. **Project → Settings → Environment Variables**
+2. Production :
+
+```
+VITE_PAYMENT_ORCHESTRATION_V2=true
+VITE_SUPABASE_URL=https://<project>.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_...
+```
+
+3. Redéployer production.
+4. **Staging / Preview** : laisser non défini pour auto-V2, ou `true` explicitement.
+
+---
+
+## 6. Checklist vendeur (onboarding)
+
+- [ ] Dashboard → **Connexions paiement**
+- [ ] Stripe Connect : onboarding Express → statut **Actif**
+- [ ] PayPal Commerce : partner onboarding → merchant **Actif**
+- [ ] Devise boutique compatible (EUR/USD pour Connect, XOF pour Moneroo)
+- [ ] Test commande 1 € / 1 $ sur staging
+
+---
+
+## 7. Checklist QA go-live (smoke prod)
+
+| #   | Scénario                    | Critère succès                                                                  |
+| --- | --------------------------- | ------------------------------------------------------------------------------- |
+| 1   | Digital XOF Moneroo         | `orders.payment_status=paid`, `status=completed`, download OK                   |
+| 2   | Physique XOF                | `status=confirmed`, `store_earnings` créé                                       |
+| 3   | Stripe EUR boutique Connect | Redirect Stripe → `/payment/success` → order paid                               |
+| 4   | PayPal USD                  | Capture webhook → fulfillment                                                   |
+| 5   | Remboursement digital       | `payment_status=refunded`, licence révoquée (`revoke_digital_access_for_order`) |
+| 6   | Panier 2 boutiques + Stripe | Message « Moneroo requis » (garde multi-store)                                  |
+| 7   | Idempotence webhook         | Rejouer event → `payment_webhook_events` duplicate, pas double fulfillment      |
+
+Commandes :
+
+```bash
+npx vitest run src/lib/payments/__tests__/
+VITE_PAYMENT_ORCHESTRATION_V2=true npx playwright test tests/e2e/checkout-multi-psp.spec.ts
+npx playwright test tests/e2e/order-paid-fulfillment.spec.ts
+```
+
+---
+
+## 8. Pipeline remboursements unifié (phase 3)
+
+Tous les PSP convergent vers `apply-payment-refund.ts` :
+
+| PSP             | Déclencheur                | Révocation digital                    |
+| --------------- | -------------------------- | ------------------------------------- |
+| Moneroo         | Webhook `refunded`         | RPC `revoke_digital_access_for_order` |
+| Stripe Connect  | `charge.refunded`          | Idem                                  |
+| PayPal Commerce | `PAYMENT.CAPTURE.REFUNDED` | Idem                                  |
+
+Idempotence : `payment_webhook_events.external_event_id` (unique par provider) + `applyPaymentRefund` skip si `transaction.status=refunded`.
+
+Monitoring :
+
+```sql
+SELECT provider, event_type, processing_error, created_at
+FROM payment_webhook_events
+WHERE processing_error IS NOT NULL
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+---
+
+## 9. Rollback
+
+1. Vercel : `VITE_PAYMENT_ORCHESTRATION_V2=false` → checkout Moneroo seul (comportement legacy).
+2. Ne pas supprimer les connexions vendeur en base.
+3. Webhooks Stripe/PayPal peuvent rester actifs (events ignorés côté checkout si V2 off).
+
+---
+
+## 10. Consolidation PR audit
+
+| PR      | Statut     | Contenu                                                              |
+| ------- | ---------- | -------------------------------------------------------------------- |
+| #15     | Mergée     | P0 statuts commande, revenus, E2E fulfillment                        |
+| #16     | Mergée     | P1 sécurité, P2 checkout/taxes/RLS                                   |
+| #17     | Mergée     | P0 FedEx prod, services, abo physique                                |
+| #18     | Mergée     | Orchestration V2 routing (inclus dans #19)                           |
+| **#19** | **Mergée** | V2 + fulfillment unifié Moneroo + multi-store guard + PaymentSuccess |
+
+**Ne pas rouvrir** #15–#18 : tout est sur `main` via la séquence ci-dessus.
+
+---
+
+## 11. Contacts & escalade
+
+| Incident                             | Action                                              |
+| ------------------------------------ | --------------------------------------------------- |
+| Double paiement / double fulfillment | Vérifier `payment_webhook_events`, logs Edge        |
+| Montant webhook ≠ commande           | `transaction_logs` event `webhook_amount_mismatch`  |
+| Connect inactif au checkout          | `store_payment_connections.external_account_status` |
+| Pas d’option Stripe au checkout      | Devise + V2 flag + connexion active                 |

--- a/docs/STRIPE_CONNECT_SETUP.md
+++ b/docs/STRIPE_CONNECT_SETUP.md
@@ -41,6 +41,7 @@ https://hbdnzajbyjakdhuavrvb.supabase.co/functions/v1/stripe-connect-webhook
 
 3. Événements à sélectionner :
    - `checkout.session.completed`
+   - `charge.refunded`
    - `account.updated`
 
 4. Créer l’endpoint → **Signing secret** → **Reveal** → copier `whsec_...`  

--- a/supabase/functions/_shared/apply-payment-refund.ts
+++ b/supabase/functions/_shared/apply-payment-refund.ts
@@ -26,8 +26,17 @@ export async function applyPaymentRefund(
     throw new Error('Transaction not found');
   }
 
+  const existingMeta =
+    transaction.metadata && typeof transaction.metadata === 'object'
+      ? (transaction.metadata as Record<string, unknown>)
+      : {};
+  const existingRefund = existingMeta.refund as { refund_id?: string } | undefined;
+
   if (transaction.status === 'refunded') {
-    return { orderId: transaction.order_id };
+    if (!existingRefund?.refund_id || existingRefund.refund_id === refund.refundId) {
+      return { orderId: transaction.order_id };
+    }
+    throw new Error('Transaction already refunded with a different refund id');
   }
 
   if (transaction.status !== 'completed') {
@@ -40,10 +49,6 @@ export async function applyPaymentRefund(
   }
 
   const now = new Date().toISOString();
-  const existingMeta =
-    transaction.metadata && typeof transaction.metadata === 'object'
-      ? (transaction.metadata as Record<string, unknown>)
-      : {};
 
   await supabase
     .from('transactions')

--- a/supabase/functions/moneroo-webhook/index.ts
+++ b/supabase/functions/moneroo-webhook/index.ts
@@ -8,6 +8,7 @@ import {
   recordWebhookEvent,
   validateOrderPaymentAmount,
 } from '../_shared/complete-order-payment.ts';
+import { applyPaymentRefund } from '../_shared/apply-payment-refund.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': Deno.env.get('SITE_URL') || 'https://www.emarzona.com',
@@ -593,22 +594,36 @@ serve(async req => {
         }
       }
     } else if (mappedStatus === 'refunded') {
+      const refundAmountRaw = payload.amount ?? transaction.amount;
+      const refundAmount =
+        typeof refundAmountRaw === 'string' ? parseFloat(refundAmountRaw) : Number(refundAmountRaw);
+
+      try {
+        await applyPaymentRefund(supabase, transaction.id, {
+          refundId: String(payload.refund_id ?? externalEventId),
+          amount: Number.isFinite(refundAmount) ? refundAmount : Number(transaction.amount ?? 0),
+          currency: String(payload.currency ?? transaction.currency ?? 'XOF'),
+          reason: typeof payload.reason === 'string' ? payload.reason : undefined,
+          provider: transaction.payment_provider || 'moneroo_platform',
+        });
+      } catch (refundError) {
+        console.error('Moneroo applyPaymentRefund failed:', refundError);
+        await supabase
+          .from('payment_webhook_events')
+          .update({
+            processing_error:
+              refundError instanceof Error ? refundError.message : 'refund_apply_failed',
+          })
+          .eq('provider', 'moneroo')
+          .eq('external_event_id', externalEventId);
+        throw refundError;
+      }
+
+      updates.status = 'refunded';
       updates.refunded_at = new Date().toISOString();
       updates.moneroo_refund_id = payload.refund_id;
       updates.moneroo_refund_amount = payload.amount;
       updates.moneroo_refund_reason = payload.reason;
-
-      // 🔧 CORRECTION : Mettre à jour l'order associée pour déclencher la mise à jour de store_earnings
-      if (transaction.order_id) {
-        await supabase
-          .from('orders')
-          .update({
-            payment_status: 'refunded',
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', transaction.order_id)
-          .then(null, (err: unknown) => console.error('Error updating order with refund:', err));
-      }
 
       // Create refund notification
       if (transaction.customer_id) {

--- a/supabase/functions/paypal-webhook/index.ts
+++ b/supabase/functions/paypal-webhook/index.ts
@@ -208,12 +208,25 @@ serve(async req => {
       }
 
       if (transactionId) {
-        await applyPaymentRefund(supabase, transactionId, {
-          refundId: resource.id as string,
-          amount: parseFloat(amountValue ?? '0'),
-          currency: amountCurrency ?? 'USD',
-          provider: 'paypal_commerce',
-        });
+        try {
+          await applyPaymentRefund(supabase, transactionId, {
+            refundId: resource.id as string,
+            amount: parseFloat(amountValue ?? '0'),
+            currency: amountCurrency ?? 'USD',
+            provider: 'paypal_commerce',
+          });
+        } catch (refundError) {
+          console.error('PayPal applyPaymentRefund failed:', refundError);
+          await supabase
+            .from('payment_webhook_events')
+            .update({
+              processing_error:
+                refundError instanceof Error ? refundError.message : 'refund_apply_failed',
+            })
+            .eq('provider', 'paypal_commerce')
+            .eq('external_event_id', event.id);
+          throw refundError;
+        }
       }
     }
 

--- a/supabase/functions/stripe-connect-webhook/index.ts
+++ b/supabase/functions/stripe-connect-webhook/index.ts
@@ -1,5 +1,5 @@
 /**
- * Stripe Connect — Webhooks (checkout.session.completed, account.updated)
+ * Stripe Connect — Webhooks (checkout.session.completed, charge.refunded, account.updated)
  */
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createSupabaseAdmin } from '../_shared/supabase-admin.ts';
@@ -9,6 +9,7 @@ import {
   markWebhookProcessed,
   recordWebhookEvent,
 } from '../_shared/complete-order-payment.ts';
+import { applyPaymentRefund } from '../_shared/apply-payment-refund.ts';
 import { runPostOrderPaymentFulfillment } from '../_shared/post-order-payment-fulfillment.ts';
 import { fromStripeAmount } from '../_shared/stripe-api.ts';
 
@@ -173,6 +174,42 @@ serve(async req => {
         if (orderId && !alreadyCompleted) {
           await runPostOrderPaymentFulfillment(supabase, orderId, transactionId);
         }
+      }
+    }
+
+    if (event.type === 'charge.refunded') {
+      const charge = event.data.object as {
+        id?: string;
+        payment_intent?: string | { id?: string };
+        amount_refunded?: number;
+        currency?: string;
+        metadata?: Record<string, string>;
+      };
+
+      const paymentIntentId =
+        typeof charge.payment_intent === 'string'
+          ? charge.payment_intent
+          : charge.payment_intent?.id;
+
+      let transactionId = charge.metadata?.transaction_id;
+
+      if (!transactionId && paymentIntentId) {
+        const { data: tx } = await supabase
+          .from('transactions')
+          .select('id, amount, currency')
+          .eq('provider_payment_intent_id', paymentIntentId)
+          .maybeSingle();
+        transactionId = tx?.id;
+      }
+
+      if (transactionId && charge.amount_refunded != null && charge.currency) {
+        const refundAmount = fromStripeAmount(charge.amount_refunded, charge.currency);
+        await applyPaymentRefund(supabase, transactionId, {
+          refundId: charge.id ?? event.id,
+          amount: refundAmount,
+          currency: charge.currency.toUpperCase(),
+          provider: 'stripe_connect',
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- Pipeline remboursements unifie: Moneroo, Stripe Connect (charge.refunded), PayPal Commerce vers apply-payment-refund.ts
- Idempotence webhook (payment_webhook_events) + refundId dans metadata transaction
- Runbook activation prod orchestration V2: docs/PAYMENT_ORCHESTRATION_V2_PROD_RUNBOOK.md
- Stripe Connect: event charge.refunded documente dans STRIPE_CONNECT_SETUP.md

## Test plan
- [ ] Deploy Edge: moneroo-webhook, stripe-connect-webhook, paypal-webhook
- [ ] Remboursement sandbox Stripe -> transaction refunded + revoke_digital_access_for_order
- [ ] Rejeu webhook refund -> pas de double log refund_completed
- [ ] Suivre runbook section 2-7 avant VITE_PAYMENT_ORCHESTRATION_V2=true en prod

Made with [Cursor](https://cursor.com)