### PR TITLE
fix(admin): scroll Personnalisation toutes sections

### DIFF
--- a/src/components/admin/customization/ContentManagementSection.tsx
+++ b/src/components/admin/customization/ContentManagementSection.tsx
@@ -34,14 +34,14 @@ const KEY_TEXTS = [
   { key: 'marketplace.title', label: 'Titre marketplace', category: 'Marketplace' },
   { key: 'marketplace.subtitle', label: 'Sous-titre marketplace', category: 'Marketplace' },
   { key: 'marketplace.searchPlaceholder', label: 'Placeholder recherche', category: 'Marketplace' },
-  
+
   // Dashboard
   { key: 'dashboard.welcome', label: 'Message de bienvenue dashboard', category: 'Dashboard' },
   { key: 'dashboard.stats.totalSales', label: 'Total ventes', category: 'Dashboard' },
   { key: 'dashboard.stats.totalOrders', label: 'Total commandes', category: 'Dashboard' },
   { key: 'dashboard.stats.totalProducts', label: 'Total produits', category: 'Dashboard' },
   { key: 'dashboard.stats.totalCustomers', label: 'Total clients', category: 'Dashboard' },
-  
+
   // Navigation
   { key: 'nav.home', label: 'Accueil', category: 'Navigation' },
   { key: 'nav.marketplace', label: 'Marketplace', category: 'Navigation' },
@@ -49,7 +49,7 @@ const KEY_TEXTS = [
   { key: 'nav.products', label: 'Produits', category: 'Navigation' },
   { key: 'nav.orders', label: 'Commandes', category: 'Navigation' },
   { key: 'nav.settings', label: 'Paramètres', category: 'Navigation' },
-  
+
   // Auth
   { key: 'auth.welcome', label: 'Bienvenue', category: 'Authentification' },
   { key: 'auth.welcomeSubtitle', label: 'Sous-titre bienvenue', category: 'Authentification' },
@@ -57,21 +57,21 @@ const KEY_TEXTS = [
   { key: 'auth.login.subtitle', label: 'Sous-titre connexion', category: 'Authentification' },
   { key: 'auth.signup.title', label: 'Titre inscription', category: 'Authentification' },
   { key: 'auth.signup.subtitle', label: 'Sous-titre inscription', category: 'Authentification' },
-  
+
   // Footer
   { key: 'footer.about', label: 'À propos (footer)', category: 'Footer' },
   { key: 'footer.contact', label: 'Contact (footer)', category: 'Footer' },
-  { key: 'footer.terms', label: 'Conditions d\'utilisation', category: 'Footer' },
+  { key: 'footer.terms', label: "Conditions d'utilisation", category: 'Footer' },
   { key: 'footer.privacy', label: 'Confidentialité', category: 'Footer' },
   { key: 'footer.help', label: 'Aide', category: 'Footer' },
-  
+
   // Erreurs
-  { key: 'errors.generic', label: 'Message d\'erreur générique', category: 'Erreurs' },
+  { key: 'errors.generic', label: "Message d'erreur générique", category: 'Erreurs' },
   { key: 'errors.notFound', label: 'Page non trouvée', category: 'Erreurs' },
   { key: 'errors.network', label: 'Erreur réseau', category: 'Erreurs' },
   { key: 'errors.unauthorized', label: 'Non autorisé', category: 'Erreurs' },
   { key: 'errors.serverError', label: 'Erreur serveur', category: 'Erreurs' },
-  
+
   // Paramètres
   { key: 'settings.title', label: 'Titre paramètres', category: 'Paramètres' },
   { key: 'settings.profile', label: 'Profil', category: 'Paramètres' },
@@ -79,12 +79,12 @@ const KEY_TEXTS = [
   { key: 'settings.payment', label: 'Paiement', category: 'Paramètres' },
   { key: 'settings.notifications', label: 'Notifications', category: 'Paramètres' },
   { key: 'settings.security', label: 'Sécurité', category: 'Paramètres' },
-  
+
   // Notifications
   { key: 'notifications.title', label: 'Titre notifications', category: 'Notifications' },
   { key: 'notifications.markAllRead', label: 'Tout marquer comme lu', category: 'Notifications' },
   { key: 'notifications.noNotifications', label: 'Aucune notification', category: 'Notifications' },
-  
+
   // Common
   { key: 'common.welcome', label: 'Bienvenue', category: 'Commun' },
   { key: 'common.loading', label: 'Chargement...', category: 'Commun' },
@@ -100,7 +100,7 @@ const KEY_TEXTS = [
   { key: 'common.back', label: 'Retour', category: 'Commun' },
   { key: 'common.next', label: 'Suivant', category: 'Commun' },
   { key: 'common.previous', label: 'Précédent', category: 'Commun' },
-  
+
   // Products
   { key: 'products.title', label: 'Titre produits', category: 'Produits' },
   { key: 'products.create', label: 'Créer produit', category: 'Produits' },
@@ -110,7 +110,7 @@ const KEY_TEXTS = [
   { key: 'products.addToCart', label: 'Ajouter au panier', category: 'Produits' },
   { key: 'products.price', label: 'Prix', category: 'Produits' },
   { key: 'products.stock', label: 'Stock', category: 'Produits' },
-  
+
   // Orders
   { key: 'orders.title', label: 'Titre commandes', category: 'Commandes' },
   { key: 'orders.status', label: 'Statut commande', category: 'Commandes' },
@@ -118,14 +118,14 @@ const KEY_TEXTS = [
   { key: 'orders.date', label: 'Date commande', category: 'Commandes' },
   { key: 'orders.view', label: 'Voir commande', category: 'Commandes' },
   { key: 'orders.cancel', label: 'Annuler commande', category: 'Commandes' },
-  
+
   // Cart
   { key: 'cart.title', label: 'Titre panier', category: 'Panier' },
   { key: 'cart.empty', label: 'Panier vide', category: 'Panier' },
   { key: 'cart.checkout', label: 'Passer commande', category: 'Panier' },
   { key: 'cart.remove', label: 'Retirer du panier', category: 'Panier' },
   { key: 'cart.total', label: 'Total panier', category: 'Panier' },
-  
+
   // Storefront
   { key: 'storefront.title', label: 'Titre boutique', category: 'Boutique' },
   { key: 'storefront.description', label: 'Description boutique', category: 'Boutique' },
@@ -144,8 +144,11 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
   const [emailTemplates, setEmailTemplates] = useState<EmailTemplate[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState<EmailTemplate | null>(null);
   const [editingTemplate, setEditingTemplate] = useState<EmailTemplate | null>(null);
-  const [templateContent, setTemplateContent] = useState<{ subject: string; html: string }>({ subject: '', html: '' });
-  
+  const [templateContent, setTemplateContent] = useState<{ subject: string; html: string }>({
+    subject: '',
+    html: '',
+  });
+
   const { data: templates, isLoading: templatesLoading } = useEmailTemplates();
 
   useEffect(() => {
@@ -171,43 +174,45 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
     }
   }, [editingTemplate, currentLanguage]);
 
-  const categories = useMemo(() => 
-    Array.from(new Set(KEY_TEXTS.map(t => t.category))), 
-    []
-  );
+  const categories = useMemo(() => Array.from(new Set(KEY_TEXTS.map(t => t.category))), []);
 
   /**
    * Textes filtrés selon la recherche et la catégorie sélectionnée
    * Mémorisé pour éviter les recalculs à chaque render
    */
-  const filteredTexts = useMemo(() => 
-    KEY_TEXTS.filter(text => {
-      const matchesSearch = text.label.toLowerCase().includes(searchText.toLowerCase()) ||
-                           text.key.toLowerCase().includes(searchText.toLowerCase());
-      const matchesCategory = selectedCategory === 'all' || text.category === selectedCategory;
-      return matchesSearch && matchesCategory;
-    }),
+  const filteredTexts = useMemo(
+    () =>
+      KEY_TEXTS.filter(text => {
+        const matchesSearch =
+          text.label.toLowerCase().includes(searchText.toLowerCase()) ||
+          text.key.toLowerCase().includes(searchText.toLowerCase());
+        const matchesCategory = selectedCategory === 'all' || text.category === selectedCategory;
+        return matchesSearch && matchesCategory;
+      }),
     [searchText, selectedCategory]
   );
 
-  const handleTextChange = useCallback((key: string, value: string) => {
-    setCustomTexts(prev => {
-      const updated = { ...prev, [key]: value };
-      // Utiliser les données à jour du state local
-      save('content', {
-        ...customizationData?.content,
-        texts: updated,
-      }).catch((error) => {
-        logger.error('Error saving text customization', { error, key, value });
+  const handleTextChange = useCallback(
+    (key: string, value: string) => {
+      setCustomTexts(prev => {
+        const updated = { ...prev, [key]: value };
+        // Utiliser les données à jour du state local
+        save('content', {
+          ...customizationData?.content,
+          texts: updated,
+        }).catch(error => {
+          logger.error('Error saving text customization', { error, key, value });
+        });
+        return updated;
       });
-      return updated;
-    });
-    if (onChange) onChange();
-  }, [customizationData, save, onChange]);
+      if (onChange) onChange();
+    },
+    [customizationData, save, onChange]
+  );
 
   /**
    * Met à jour un template d'email dans la base de données et l'état local
-   * 
+   *
    * @param updatedTemplate - Template d'email avec les modifications
    * @returns Promise qui se résout avec le template mis à jour
    * @throws Error si la mise à jour échoue
@@ -229,12 +234,10 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
 
       // Mettre à jour l'état local
       const updated = { ...updatedTemplate };
-      setEmailTemplates(prev => 
-        prev.map(t => t.id === updatedTemplate.id ? updated : t)
-      );
+      setEmailTemplates(prev => prev.map(t => (t.id === updatedTemplate.id ? updated : t)));
       setEditingTemplate(updated);
       setSelectedTemplate(updated);
-      
+
       return updated;
     } catch (error) {
       logger.error('Error updating template', { error, templateId: updatedTemplate.id });
@@ -242,24 +245,27 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
     }
   }, []);
 
-  const resetText = useCallback((key: string) => {
-    setCustomTexts(prev => {
-      const newTexts = { ...prev };
-      delete newTexts[key];
-      save('content', {
-        ...customizationData?.content,
-        texts: newTexts,
-      }).catch((error) => {
-        logger.error('Error resetting text customization', { error, key });
+  const resetText = useCallback(
+    (key: string) => {
+      setCustomTexts(prev => {
+        const newTexts = { ...prev };
+        delete newTexts[key];
+        save('content', {
+          ...customizationData?.content,
+          texts: newTexts,
+        }).catch(error => {
+          logger.error('Error resetting text customization', { error, key });
+        });
+        return newTexts;
       });
-      return newTexts;
-    });
-  }, [customizationData, save]);
+    },
+    [customizationData, save]
+  );
 
   return (
     <div className="space-y-6">
       <Tabs defaultValue="texts" className="w-full">
-        <TabsList className="grid w-full grid-cols-3 gap-1 sm:gap-2">
+        <TabsList className="grid h-auto min-h-0 w-full grid-cols-1 gap-1 sm:grid-cols-3 sm:gap-2">
           <TabsTrigger value="texts" className="text-xs sm:text-sm">
             <FileText className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
             <span className="hidden sm:inline">Textes ({KEY_TEXTS.length})</span>
@@ -282,7 +288,8 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
             <CardHeader>
               <CardTitle>Textes de la plateforme</CardTitle>
               <CardDescription>
-                Personnalisez les textes affichés sur la plateforme. Les modifications sont appliquées en temps réel.
+                Personnalisez les textes affichés sur la plateforme. Les modifications sont
+                appliquées en temps réel.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -293,7 +300,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                   <Input
                     placeholder="Rechercher un texte..."
                     value={searchText}
-                    onChange={(e) => setSearchText(e.target.value)}
+                    onChange={e => setSearchText(e.target.value)}
                     className="pl-10 text-sm"
                   />
                 </div>
@@ -323,8 +330,8 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
               <Separator />
 
               {/* Liste des textes */}
-              <div className="space-y-4 max-h-[600px] overflow-y-auto">
-                {filteredTexts.map((text: typeof KEY_TEXTS[number]) => {
+              <div className="space-y-4">
+                {filteredTexts.map((text: (typeof KEY_TEXTS)[number]) => {
                   const currentValue = customTexts[text.key] || text.key;
                   const isCustom = !!customTexts[text.key];
 
@@ -343,11 +350,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                               </Badge>
                             </div>
                             {isCustom && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => resetText(text.key)}
-                              >
+                              <Button variant="ghost" size="sm" onClick={() => resetText(text.key)}>
                                 <RefreshCw className="h-3 w-3 mr-1" />
                                 Réinitialiser
                               </Button>
@@ -359,7 +362,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                             </Label>
                             <Textarea
                               value={currentValue}
-                              onChange={(e) => handleTextChange(text.key, e.target.value)}
+                              onChange={e => handleTextChange(text.key, e.target.value)}
                               rows={2}
                               className="font-medium"
                             />
@@ -387,12 +390,11 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                 <div>
                   <CardTitle>Modèles d'emails</CardTitle>
                   <CardDescription>
-                    Personnalisez les emails envoyés aux utilisateurs. Les templates sont multilingues et supportent des variables dynamiques.
+                    Personnalisez les emails envoyés aux utilisateurs. Les templates sont
+                    multilingues et supportent des variables dynamiques.
                   </CardDescription>
                 </div>
-                {templatesLoading && (
-                  <Badge variant="outline">Chargement...</Badge>
-                )}
+                {templatesLoading && <Badge variant="outline">Chargement...</Badge>}
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -404,15 +406,17 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                 <div className="text-center py-8 text-muted-foreground">
                   <Mail className="h-12 w-12 mx-auto mb-4 opacity-50" />
                   <p>Aucun template d'email trouvé.</p>
-                  <p className="text-sm mt-2">Les templates seront créés automatiquement lors de leur première utilisation.</p>
+                  <p className="text-sm mt-2">
+                    Les templates seront créés automatiquement lors de leur première utilisation.
+                  </p>
                 </div>
               ) : (
                 <div className="space-y-4">
                   {/* Liste des templates */}
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
-                    {emailTemplates.map((template) => (
-                      <Card 
-                        key={template.id} 
+                    {emailTemplates.map(template => (
+                      <Card
+                        key={template.id}
                         className={`cursor-pointer transition-all hover:shadow-md ${
                           selectedTemplate?.id === template.id ? 'ring-2 ring-primary' : ''
                         }`}
@@ -444,7 +448,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                             <Button
                               variant="ghost"
                               size="sm"
-                              onClick={(e) => {
+                              onClick={e => {
                                 e.stopPropagation();
                                 setSelectedTemplate(template);
                                 setEditingTemplate(template);
@@ -478,7 +482,8 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                           <div>
                             <CardTitle>Éditer: {editingTemplate.name}</CardTitle>
                             <CardDescription>
-                              Slug: <code className="bg-muted px-1 rounded">{editingTemplate.slug}</code>
+                              Slug:{' '}
+                              <code className="bg-muted px-1 rounded">{editingTemplate.slug}</code>
                             </CardDescription>
                           </div>
                           <Button
@@ -500,7 +505,9 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                             <Label>Sujet (FR)</Label>
                             <Input
                               value={templateContent.subject}
-                              onChange={(e) => setTemplateContent(prev => ({ ...prev, subject: e.target.value }))}
+                              onChange={e =>
+                                setTemplateContent(prev => ({ ...prev, subject: e.target.value }))
+                              }
                               placeholder="Sujet de l'email en français"
                             />
                           </div>
@@ -511,9 +518,12 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                                 <input
                                   type="checkbox"
                                   checked={editingTemplate.is_active}
-                                  onChange={async (e) => {
+                                  onChange={async e => {
                                     try {
-                                      const updated = { ...editingTemplate, is_active: e.target.checked };
+                                      const updated = {
+                                        ...editingTemplate,
+                                        is_active: e.target.checked,
+                                      };
                                       await updateTemplate(updated);
                                     } catch (_error) {
                                       toast({
@@ -531,9 +541,12 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                                 <input
                                   type="checkbox"
                                   checked={editingTemplate.is_default}
-                                  onChange={async (e) => {
+                                  onChange={async e => {
                                     try {
-                                      const updated = { ...editingTemplate, is_default: e.target.checked };
+                                      const updated = {
+                                        ...editingTemplate,
+                                        is_default: e.target.checked,
+                                      };
                                       await updateTemplate(updated);
                                     } catch (_error) {
                                       toast({
@@ -554,21 +567,30 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                           <Label>Contenu HTML (FR)</Label>
                           <Textarea
                             value={templateContent.html}
-                            onChange={(e) => setTemplateContent(prev => ({ ...prev, html: e.target.value }))}
+                            onChange={e =>
+                              setTemplateContent(prev => ({ ...prev, html: e.target.value }))
+                            }
                             placeholder="Contenu HTML de l'email en français"
                             rows={12}
                             className="font-mono text-sm"
                           />
                           <p className="text-xs text-muted-foreground">
-                            Variables disponibles: {editingTemplate.variables.join(', ') || 'Aucune'}
+                            Variables disponibles:{' '}
+                            {editingTemplate.variables.join(', ') || 'Aucune'}
                           </p>
                         </div>
                         <div className="flex gap-2">
                           <Button
                             onClick={async () => {
                               try {
-                                const updatedSubject = { ...editingTemplate.subject, fr: templateContent.subject };
-                                const updatedHtml = { ...editingTemplate.html_content, fr: templateContent.html };
+                                const updatedSubject = {
+                                  ...editingTemplate.subject,
+                                  fr: templateContent.subject,
+                                };
+                                const updatedHtml = {
+                                  ...editingTemplate.html_content,
+                                  fr: templateContent.html,
+                                };
                                 const updated = {
                                   ...editingTemplate,
                                   subject: updatedSubject,
@@ -626,7 +648,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                   <Input
                     placeholder="Vous avez reçu une nouvelle commande"
                     defaultValue={customizationData?.content?.notifications?.newOrder || ''}
-                    onChange={(e) => {
+                    onChange={e => {
                       save('content', {
                         ...customizationData?.content,
                         notifications: {
@@ -642,7 +664,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                   <Input
                     placeholder="Paiement reçu avec succès"
                     defaultValue={customizationData?.content?.notifications?.paymentReceived || ''}
-                    onChange={(e) => {
+                    onChange={e => {
                       save('content', {
                         ...customizationData?.content,
                         notifications: {
@@ -658,7 +680,7 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
                   <Input
                     placeholder="Vous avez reçu un nouveau message"
                     defaultValue={customizationData?.content?.notifications?.newMessage || ''}
-                    onChange={(e) => {
+                    onChange={e => {
                       save('content', {
                         ...customizationData?.content,
                         notifications: {
@@ -677,9 +699,3 @@ export const ContentManagementSection = ({ onChange }: ContentManagementSectionP
     </div>
   );
 };
-
-
-
-
-
-

--- a/src/components/admin/customization/DesignBrandingSection.tsx
+++ b/src/components/admin/customization/DesignBrandingSection.tsx
@@ -584,7 +584,7 @@ export const DesignBrandingSection = ({ onChange }: DesignBrandingSectionProps) 
   return (
     <div className="space-y-4 sm:space-y-6">
       <Tabs defaultValue="colors" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 gap-1 sm:gap-2">
+        <TabsList className="grid h-auto min-h-0 w-full grid-cols-2 gap-1 sm:grid-cols-4 sm:gap-2">
           <TabsTrigger value="colors" className="text-xs sm:text-sm">
             <Palette className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
             <span className="hidden sm:inline">Couleurs</span>
@@ -983,7 +983,10 @@ export const DesignBrandingSection = ({ onChange }: DesignBrandingSectionProps) 
                     <button
                       key={key}
                       onClick={() => {
-                        setLocalDesignTokens(prev => ({ ...prev, shadow: key as typeof prev.shadow }));
+                        setLocalDesignTokens(prev => ({
+                          ...prev,
+                          shadow: key as typeof prev.shadow,
+                        }));
                         const shadows = {
                           sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
                           base: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
@@ -1002,7 +1005,16 @@ export const DesignBrandingSection = ({ onChange }: DesignBrandingSectionProps) 
                             ...customizationData?.design,
                             tokens: {
                               ...customizationData?.design?.tokens,
-                              shadow: key as "base" | "glow" | "large" | "lg" | "md" | "medium" | "sm" | "soft" | "xl",
+                              shadow: key as
+                                | 'base'
+                                | 'glow'
+                                | 'large'
+                                | 'lg'
+                                | 'md'
+                                | 'medium'
+                                | 'sm'
+                                | 'soft'
+                                | 'xl',
                             },
                           },
                         };

--- a/src/components/admin/customization/FeaturesSection.tsx
+++ b/src/components/admin/customization/FeaturesSection.tsx
@@ -529,7 +529,7 @@ export const FeaturesSection = ({ onChange }: FeaturesSectionProps) => {
           <Separator />
 
           {/* Liste des fonctionnalités */}
-          <div className="space-y-3 max-h-[600px] overflow-y-auto">
+          <div className="space-y-3">
             {filteredFeatures.map(feature => {
               const Icon = feature.icon;
 

--- a/src/components/admin/customization/IntegrationsSection.tsx
+++ b/src/components/admin/customization/IntegrationsSection.tsx
@@ -26,7 +26,6 @@ import {
 } from 'lucide-react';
 import { usePlatformCustomization } from '@/hooks/admin/usePlatformCustomization';
 import { useToast } from '@/hooks/use-toast';
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { stripIntegrationsTree } from '@/lib/admin/integration-secrets';
 
 interface IntegrationsSectionProps {
@@ -149,31 +148,42 @@ export const IntegrationsSection = ({ onChange }: IntegrationsSectionProps) => {
   return (
     <div className="space-y-6">
       <Tabs defaultValue="payments" className="w-full">
-        <ScrollArea className="w-full whitespace-nowrap rounded-md border mb-4">
-          <TabsList className="inline-flex w-full justify-start p-1">
-            <TabsTrigger value="payments" className="text-xs sm:text-sm shrink-0">
+        <div className="platform-customization-section-tabs mb-4 w-full overflow-x-auto rounded-md border">
+          <TabsList className="inline-flex h-auto min-h-0 w-max min-w-full justify-start gap-1 rounded-none border-0 bg-transparent p-1">
+            <TabsTrigger
+              value="payments"
+              className="h-auto min-h-[2.5rem] shrink-0 px-2 py-1.5 text-xs sm:px-3 sm:text-sm"
+            >
               <CreditCard className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
               <span className="hidden sm:inline">Paiements</span>
               <span className="sm:hidden">Pay</span>
             </TabsTrigger>
-            <TabsTrigger value="video" className="text-xs sm:text-sm shrink-0">
+            <TabsTrigger
+              value="video"
+              className="h-auto min-h-[2.5rem] shrink-0 px-2 py-1.5 text-xs sm:px-3 sm:text-sm"
+            >
               <Video className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
               <span className="hidden sm:inline">Vidéo</span>
               <span className="sm:hidden">Vidéo</span>
             </TabsTrigger>
-            <TabsTrigger value="shipping" className="text-xs sm:text-sm shrink-0">
+            <TabsTrigger
+              value="shipping"
+              className="h-auto min-h-[2.5rem] shrink-0 px-2 py-1.5 text-xs sm:px-3 sm:text-sm"
+            >
               <Truck className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
               <span className="hidden sm:inline">Livraison</span>
               <span className="sm:hidden">Ship</span>
             </TabsTrigger>
-            <TabsTrigger value="analytics" className="text-xs sm:text-sm shrink-0">
+            <TabsTrigger
+              value="analytics"
+              className="h-auto min-h-[2.5rem] shrink-0 px-2 py-1.5 text-xs sm:px-3 sm:text-sm"
+            >
               <BarChart3 className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
               <span className="hidden sm:inline">Analytics</span>
               <span className="sm:hidden">Analytics</span>
             </TabsTrigger>
           </TabsList>
-          <ScrollBar orientation="horizontal" />
-        </ScrollArea>
+        </div>
 
         {/* Paiements */}
         <TabsContent value="payments" className="space-y-4">

--- a/src/components/admin/customization/LandingPageCustomizationSection.tsx
+++ b/src/components/admin/customization/LandingPageCustomizationSection.tsx
@@ -17,7 +17,6 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { OptimizedImage } from '@/components/ui/OptimizedImage';
 import { Switch } from '@/components/ui/switch';
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { logger } from '@/lib/logger';
 import {
   LANDING_PREMIUM_PAGE_ID,
@@ -353,15 +352,15 @@ export const LandingPageCustomizationSection = ({
   const editorContent = (
     <Tabs value={selectedSection} onValueChange={setSelectedSection}>
       {LANDING_SECTIONS.length > 1 ? (
-        <ScrollArea className="w-full whitespace-nowrap rounded-md border mb-4">
-          <TabsList className="inline-flex w-full justify-start p-1">
+        <div className="platform-customization-section-tabs mb-4 w-full overflow-x-auto rounded-md border">
+          <TabsList className="inline-flex h-auto min-h-0 w-max min-w-full justify-start gap-1 rounded-none border-0 bg-transparent p-1">
             {LANDING_SECTIONS.map(section => {
               const Icon = section.icon;
               return (
                 <TabsTrigger
                   key={section.id}
                   value={section.id}
-                  className="text-xs sm:text-sm shrink-0"
+                  className="h-auto min-h-[2.5rem] shrink-0 px-2 py-1.5 text-xs sm:px-3 sm:text-sm"
                 >
                   <Icon className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
                   <span className="hidden sm:inline">{section.name}</span>
@@ -370,8 +369,7 @@ export const LandingPageCustomizationSection = ({
               );
             })}
           </TabsList>
-          <ScrollBar orientation="horizontal" />
-        </ScrollArea>
+        </div>
       ) : null}
 
       {selectedSectionConfig && (

--- a/src/components/admin/customization/PagesCustomizationSection.tsx
+++ b/src/components/admin/customization/PagesCustomizationSection.tsx
@@ -8,7 +8,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { Layout, RefreshCw } from 'lucide-react';
 import { PAGES_CONFIG } from './pages/pagesConfig';
 import { PageElementEditor } from './pages/PageElementEditor';
@@ -106,20 +105,19 @@ export const PagesCustomizationSection = ({ onChange }: PagesCustomizationSectio
               value={selectedSection || selectedPageConfig.sections[0]?.id}
               onValueChange={setSelectedSection}
             >
-              <ScrollArea className="w-full whitespace-nowrap rounded-md border">
-                <TabsList className="inline-flex w-full justify-start p-1">
+              <div className="platform-customization-section-tabs mb-4 w-full overflow-x-auto rounded-md border">
+                <TabsList className="inline-flex h-auto min-h-0 w-max min-w-full justify-start gap-1 rounded-none border-0 bg-transparent p-1">
                   {selectedPageConfig.sections.map(section => (
                     <TabsTrigger
                       key={section.id}
                       value={section.id}
-                      className="text-xs sm:text-sm shrink-0"
+                      className="h-auto min-h-[2.5rem] shrink-0 px-2 py-1.5 text-xs sm:px-3 sm:text-sm"
                     >
                       {section.name}
                     </TabsTrigger>
                   ))}
                 </TabsList>
-                <ScrollBar orientation="horizontal" />
-              </ScrollArea>
+              </div>
 
               {selectedPageConfig.sections.map(section => (
                 <TabsContent key={section.id} value={section.id} className="space-y-4 mt-4">

--- a/src/pages/admin/PlatformCustomization.tsx
+++ b/src/pages/admin/PlatformCustomization.tsx
@@ -191,6 +191,7 @@ export const PlatformCustomization = () => {
   const [isImporting, setIsImporting] = useState(false);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const panelRef = React.useRef<HTMLDivElement>(null);
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
   const { toast } = useToast();
   const {
     saveAll,
@@ -235,12 +236,13 @@ export const PlatformCustomization = () => {
     navigate(buildSectionHref('design'), { replace: true });
   }, [location.search, navigate]);
 
-  // Mobile : faire défiler vers le contenu après changement de section
+  // Remonter le panneau contenu au changement de section (desktop + mobile)
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (!window.matchMedia('(max-width: 1023px)').matches) return;
     requestAnimationFrame(() => {
-      panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+      if (typeof window !== 'undefined' && window.matchMedia('(max-width: 1023px)').matches) {
+        panelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     });
   }, [activeSection]);
 
@@ -371,7 +373,7 @@ export const PlatformCustomization = () => {
             className={cn(
               'relative z-50 flex w-full shrink-0 flex-col border-b bg-card/50 backdrop-blur-sm',
               'max-h-[min(48vh,28rem)] lg:max-h-none',
-              'lg:col-start-1 lg:row-start-1',
+              'lg:col-start-1 lg:row-start-1 lg:overflow-hidden',
               'lg:h-full lg:w-full lg:max-w-none lg:shrink-0 lg:border-b-0 lg:border-r'
             )}
           >
@@ -471,18 +473,22 @@ export const PlatformCustomization = () => {
             ref={panelRef}
             id="platform-customization-panel"
             className={cn(
-              'relative z-0 flex min-w-0 flex-col',
+              'relative z-0 flex min-h-0 min-w-0 flex-col',
               'lg:col-start-2 lg:row-start-1',
               'min-h-[min(50vh,32rem)] lg:min-h-0 lg:overflow-hidden'
             )}
           >
             {/* Indication mobile : le contenu est sous la liste */}
-            <p className="border-b bg-muted/40 px-4 py-2 text-center text-xs text-muted-foreground lg:hidden">
+            <p className="shrink-0 border-b bg-muted/40 px-4 py-2 text-center text-xs text-muted-foreground lg:hidden">
               Section :{' '}
               <span className="font-medium text-foreground">{activeSectionConfig?.label}</span>
               {' — '}faites défiler pour modifier
             </p>
-            <div className="min-h-0 flex-1 overflow-y-auto pb-20 lg:pb-0">
+            <div
+              ref={scrollContainerRef}
+              id="platform-customization-scroll"
+              className="platform-customization-scroll min-h-0 flex-1 overflow-y-auto overflow-x-hidden pb-24 lg:pb-8"
+            >
               <div className="container mx-auto max-w-6xl p-4 sm:p-6">
                 {/* Header - Responsive */}
                 <div className="mb-4 sm:mb-6">

--- a/src/styles/app-premium.css
+++ b/src/styles/app-premium.css
@@ -474,6 +474,12 @@
   }
 }
 
+#platform-customization-scroll {
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  scroll-padding-bottom: 2rem;
+}
+
 @media (max-width: 1023px) {
   #platform-customization-nav {
     max-height: min(48vh, 28rem);
@@ -483,4 +489,15 @@
     min-height: min(55vh, 36rem);
     scroll-margin-top: 4.5rem;
   }
+
+  .platform-customization-shell {
+    min-height: 0;
+  }
+}
+
+/* Onglets horizontaux : défilement natif (évite ScrollArea qui masque le contenu) */
+.platform-customization-section-tabs {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
 }


### PR DESCRIPTION
## Summary
- Remonte le panneau contenu en haut à chaque changement de section (desktop + mobile)
- Supprime les scrolls imbriqués (Contenu, Fonctionnalités) qui masquaient des éléments
- Remplace ScrollArea par overflow-x natif sur les onglets horizontaux (Landing, Pages, Intégrations)
- Améliore padding bas mobile et layout grille aside/panneau

## Test plan
- [ ] Parcourir chaque section Personnalisation et scroller jusqu''en bas
- [ ] Vérifier onglets Couleurs/Logos/Typo/Tokens (Design)
- [ ] Vérifier listes longues Contenu & Textes et Fonctionnalités
- [ ] Tester mobile : menu + contenu empilés, scroll fluide