### PR TITLE
fix(admin): Phase 1 P0 integrity for platform admin panel

### DIFF
--- a/src/components/admin/customization/FeaturesSection.tsx
+++ b/src/components/admin/customization/FeaturesSection.tsx
@@ -205,7 +205,7 @@ const ALL_FEATURES: Feature[] = [
     category: 'Commerce',
     icon: Star,
     enabled: true,
-    route: '/dashboard/wishlist',
+    route: '/account/wishlist',
   },
   {
     id: 'coupons',
@@ -214,7 +214,7 @@ const ALL_FEATURES: Feature[] = [
     category: 'Commerce',
     icon: Gift,
     enabled: true,
-    route: '/admin/coupons',
+    route: '/dashboard/coupons',
   },
   {
     id: 'reviews',
@@ -232,7 +232,7 @@ const ALL_FEATURES: Feature[] = [
     category: 'Commerce',
     icon: CreditCard,
     enabled: true,
-    route: '/dashboard/subscriptions',
+    route: '/admin/subscriptions',
   },
   {
     id: 'invoicing',
@@ -241,7 +241,7 @@ const ALL_FEATURES: Feature[] = [
     category: 'Commerce',
     icon: FileText,
     enabled: true,
-    route: '/dashboard/invoices',
+    route: '/account/invoices',
   },
 
   // Produits avancés
@@ -294,7 +294,7 @@ const ALL_FEATURES: Feature[] = [
     category: 'Marketplace',
     icon: Shield,
     enabled: true,
-    route: '/admin/vendors',
+    route: '/admin/stores',
   },
   {
     id: 'disputes',
@@ -314,7 +314,6 @@ const ALL_FEATURES: Feature[] = [
     category: 'Communication',
     icon: MessageSquare,
     enabled: true,
-    route: '/dashboard/messages',
   },
   {
     id: 'live_chat',
@@ -331,7 +330,7 @@ const ALL_FEATURES: Feature[] = [
     category: 'Communication',
     icon: Bell,
     enabled: true,
-    route: '/admin/announcements',
+    route: '/admin/notifications',
   },
 
   // Analytics & Reporting

--- a/src/components/admin/customization/PlatformSettingsSection.tsx
+++ b/src/components/admin/customization/PlatformSettingsSection.tsx
@@ -3,152 +3,62 @@
  * Commissions, retraits, limites
  */
 
+import { Link } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
-import { DollarSign, Wallet, Users, Info, CreditCard, ShoppingCart } from '@/components/icons';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { DollarSign, Users, Info, CreditCard, ShoppingCart } from '@/components/icons';
+import { ArrowRight } from 'lucide-react';
 import { usePlatformCustomization } from '@/hooks/admin/usePlatformCustomization';
-import { usePlatformSettingsDirect } from '@/hooks/usePlatformSettingsDirect';
+
+interface PlatformCustomizationSettings {
+  payment?: {
+    delayDays?: number;
+    currencies?: string[];
+  };
+  marketplace?: {
+    commissionRate?: number;
+    listingFee?: number;
+  };
+  limits?: {
+    maxProducts?: number;
+    maxStores?: number;
+    maxOrdersPerDay?: number;
+    maxWithdrawalsPerMonth?: number;
+    maxFileSizeMB?: number;
+  };
+}
 
 interface PlatformSettingsSectionProps {
   onChange?: () => void;
 }
 
-export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionProps) => {
+export const PlatformSettingsSection = ({ onChange: _onChange }: PlatformSettingsSectionProps) => {
   const { customizationData, save } = usePlatformCustomization();
-  const { settings, updateSettings, isLoading } = usePlatformSettingsDirect();
-
-  const handleSettingChange = (updates: Record<string, unknown>) => {
-    if (settings) {
-      updateSettings(updates);
-    }
-    if (onChange) onChange();
-  };
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <div className="flex flex-col items-center gap-4">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
-          <p className="text-muted-foreground">Chargement des paramètres...</p>
-        </div>
-      </div>
-    );
-  }
+  const settings = (customizationData?.settings ?? {}) as PlatformCustomizationSettings;
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      {/* Commissions */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <DollarSign className="h-5 w-5" />
-            Commissions
-          </CardTitle>
-          <CardDescription>
-            Configurez les taux de commission de la plateforme
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="platform-commission">
-              Commission plateforme (%)
-            </Label>
-            <Input
-              id="platform-commission"
-              type="number"
-              min="0"
-              max="100"
-              step="0.01"
-              value={settings?.platform_commission_rate || 10}
-              onChange={(e) => {
-                handleSettingChange({
-                  platform_commission_rate: parseFloat(e.target.value),
-                });
-              }}
-            />
-            <p className="text-xs text-muted-foreground">
-              Pourcentage prélevé sur chaque vente
-            </p>
-          </div>
-
-          <Separator />
-
-          <div className="space-y-2">
-            <Label htmlFor="referral-commission">
-              Commission parrainage (%)
-            </Label>
-            <Input
-              id="referral-commission"
-              type="number"
-              min="0"
-              max="100"
-              step="0.01"
-              value={settings?.referral_commission_rate || 2}
-              onChange={(e) => {
-                handleSettingChange({
-                  referral_commission_rate: parseFloat(e.target.value),
-                });
-              }}
-            />
-            <p className="text-xs text-muted-foreground">
-              Pourcentage versé aux parrains
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Retraits */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Wallet  className ="h-5 w-5" />
-            Retraits
-          </CardTitle>
-          <CardDescription>
-            Paramètres de retrait pour les vendeurs
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="min-withdrawal">
-              Montant minimum de retrait (FCFA)
-            </Label>
-            <Input
-              id="min-withdrawal"
-              type="number"
-              min="0"
-              value={settings?.min_withdrawal_amount || 10000}
-              onChange={(e) => {
-                handleSettingChange({
-                  min_withdrawal_amount: parseInt(e.target.value),
-                });
-              }}
-            />
-          </div>
-
-          <Separator />
-
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label>Approbation automatique</Label>
-              <p className="text-xs text-muted-foreground">
-                Les retraits sont approuvés automatiquement
-              </p>
-            </div>
-            <Switch
-              checked={settings?.auto_approve_withdrawals || false}
-              onCheckedChange={(checked) => {
-                handleSettingChange({
-                  auto_approve_withdrawals: checked,
-                });
-              }}
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <Alert>
+        <Info className="h-4 w-4" />
+        <AlertDescription className="space-y-3">
+          <p>
+            Les commissions, retraits et notifications financières sont gérés sur la page dédiée
+            (source unique <code className="bg-muted px-1 rounded text-xs">platform_settings</code>
+            ).
+          </p>
+          <Button asChild variant="outline" size="sm" className="gap-2">
+            <Link to="/admin/commission-settings">
+              <DollarSign className="h-4 w-4" />
+              Paramètres de commission
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </Button>
+        </AlertDescription>
+      </Alert>
 
       {/* Limites */}
       <Card>
@@ -157,60 +67,52 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
             <Users className="h-5 w-5" />
             Limites
           </CardTitle>
-          <CardDescription>
-            Limites par utilisateur ou boutique
-          </CardDescription>
+          <CardDescription>Limites par utilisateur ou boutique</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="max-products">
-              Nombre maximum de produits par boutique
-            </Label>
+            <Label htmlFor="max-products">Nombre maximum de produits par boutique</Label>
             <Input
               id="max-products"
               type="number"
               min="0"
-              value={customizationData?.settings?.limits?.maxProducts || 0}
-              onChange={(e) => {
+              value={settings.limits?.maxProducts || 0}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   limits: {
-                    ...customizationData?.settings?.limits,
+                    ...settings.limits,
                     maxProducts: parseInt(e.target.value) || 0,
                   },
                 });
               }}
             />
             <p className="text-xs text-muted-foreground flex items-center gap-1">
-              <Info className="h-3 w-3" />
-              0 = illimité
+              <Info className="h-3 w-3" />0 = illimité
             </p>
           </div>
 
           <Separator />
 
           <div className="space-y-2">
-            <Label htmlFor="max-stores">
-              Nombre maximum de boutiques par utilisateur
-            </Label>
+            <Label htmlFor="max-stores">Nombre maximum de boutiques par utilisateur</Label>
             <Input
               id="max-stores"
               type="number"
               min="0"
-              value={customizationData?.settings?.limits?.maxStores || 0}
-              onChange={(e) => {
+              value={settings.limits?.maxStores || 0}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   limits: {
-                    ...customizationData?.settings?.limits,
+                    ...settings.limits,
                     maxStores: parseInt(e.target.value) || 0,
                   },
                 });
               }}
             />
             <p className="text-xs text-muted-foreground flex items-center gap-1">
-              <Info className="h-3 w-3" />
-              0 = illimité
+              <Info className="h-3 w-3" />0 = illimité
             </p>
           </div>
         </CardContent>
@@ -223,26 +125,22 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
             <CreditCard className="h-5 w-5" />
             Paiements
           </CardTitle>
-          <CardDescription>
-            Configuration des délais et méthodes de paiement
-          </CardDescription>
+          <CardDescription>Configuration des délais et méthodes de paiement</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="payment-delay">
-              Délai de paiement aux vendeurs (jours)
-            </Label>
+            <Label htmlFor="payment-delay">Délai de paiement aux vendeurs (jours)</Label>
             <Input
               id="payment-delay"
               type="number"
               min="0"
               max="30"
-              value={(customizationData?.settings as Record<string, any>)?.payment?.delayDays || 7}
-              onChange={(e) => {
+              value={settings.payment?.delayDays || 7}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   payment: {
-                    ...(customizationData?.settings as Record<string, any>)?.payment,
+                    ...settings.payment,
                     delayDays: parseInt(e.target.value) || 7,
                   },
                 });
@@ -258,20 +156,20 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
           <div className="space-y-2">
             <Label>Devises supportées</Label>
             <div className="flex flex-wrap gap-2">
-              {['XOF', 'EUR', 'USD', 'XAF'].map((currency) => (
+              {['XOF', 'EUR', 'USD', 'XAF'].map(currency => (
                 <div key={currency} className="flex items-center gap-2">
                   <input
                     type="checkbox"
-                    checked={(customizationData?.settings as Record<string, any>)?.payment?.currencies?.includes(currency) ?? true}
-                    onChange={(e) => {
-                      const currencies = (customizationData?.settings as Record<string, any>)?.payment?.currencies || ['XOF'];
+                    checked={settings.payment?.currencies?.includes(currency) ?? true}
+                    onChange={e => {
+                      const currencies = settings.payment?.currencies || ['XOF'];
                       const updated = e.target.checked
                         ? [...currencies, currency]
-                        : currencies.filter((c: string) => c !== currency);
+                        : currencies.filter(c => c !== currency);
                       save('settings', {
-                        ...customizationData?.settings,
+                        ...settings,
                         payment: {
-                          ...(customizationData?.settings as Record<string, any>)?.payment,
+                          ...settings.payment,
                           currencies: updated,
                         },
                       });
@@ -293,27 +191,23 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
             <ShoppingCart className="h-5 w-5" />
             Marketplace
           </CardTitle>
-          <CardDescription>
-            Configuration de la marketplace
-          </CardDescription>
+          <CardDescription>Configuration de la marketplace</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="marketplace-commission">
-              Commission marketplace (%)
-            </Label>
+            <Label htmlFor="marketplace-commission">Commission marketplace (%)</Label>
             <Input
               id="marketplace-commission"
               type="number"
               min="0"
               max="100"
               step="0.01"
-              value={(customizationData?.settings as Record<string, any>)?.marketplace?.commissionRate || 5}
-              onChange={(e) => {
+              value={settings.marketplace?.commissionRate || 5}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   marketplace: {
-                    ...(customizationData?.settings as Record<string, any>)?.marketplace,
+                    ...settings.marketplace,
                     commissionRate: parseFloat(e.target.value) || 5,
                   },
                 });
@@ -327,19 +221,17 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
           <Separator />
 
           <div className="space-y-2">
-            <Label htmlFor="listing-fee">
-              Frais de listing par produit (FCFA)
-            </Label>
+            <Label htmlFor="listing-fee">Frais de listing par produit (FCFA)</Label>
             <Input
               id="listing-fee"
               type="number"
               min="0"
-              value={(customizationData?.settings as Record<string, any>)?.marketplace?.listingFee || 0}
-              onChange={(e) => {
+              value={settings.marketplace?.listingFee || 0}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   marketplace: {
-                    ...(customizationData?.settings as Record<string, any>)?.marketplace,
+                    ...settings.marketplace,
                     listingFee: parseInt(e.target.value) || 0,
                   },
                 });
@@ -359,79 +251,69 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
             <Info className="h-5 w-5" />
             Limites supplémentaires
           </CardTitle>
-          <CardDescription>
-            Limites de commandes et retraits
-          </CardDescription>
+          <CardDescription>Limites de commandes et retraits</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="max-orders-per-day">
-              Commandes maximum par jour
-            </Label>
+            <Label htmlFor="max-orders-per-day">Commandes maximum par jour</Label>
             <Input
               id="max-orders-per-day"
               type="number"
               min="0"
-              value={(customizationData?.settings?.limits as Record<string, any>)?.maxOrdersPerDay || 0}
-              onChange={(e) => {
+              value={settings.limits?.maxOrdersPerDay || 0}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   limits: {
-                    ...customizationData?.settings?.limits,
+                    ...settings.limits,
                     maxOrdersPerDay: parseInt(e.target.value) || 0,
                   },
                 });
               }}
             />
             <p className="text-xs text-muted-foreground flex items-center gap-1">
-              <Info className="h-3 w-3" />
-              0 = illimité
+              <Info className="h-3 w-3" />0 = illimité
             </p>
           </div>
 
           <Separator />
 
           <div className="space-y-2">
-            <Label htmlFor="max-withdrawals-per-month">
-              Retraits maximum par mois
-            </Label>
+            <Label htmlFor="max-withdrawals-per-month">Retraits maximum par mois</Label>
             <Input
               id="max-withdrawals-per-month"
               type="number"
               min="0"
-              value={(customizationData?.settings?.limits as Record<string, any>)?.maxWithdrawalsPerMonth || 0}
-              onChange={(e) => {
+              value={settings.limits?.maxWithdrawalsPerMonth || 0}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   limits: {
-                    ...customizationData?.settings?.limits,
+                    ...settings.limits,
                     maxWithdrawalsPerMonth: parseInt(e.target.value) || 0,
                   },
                 });
               }}
             />
             <p className="text-xs text-muted-foreground flex items-center gap-1">
-              <Info className="h-3 w-3" />
-              0 = illimité
+              <Info className="h-3 w-3" />0 = illimité
             </p>
           </div>
 
           <Separator />
 
           <div className="space-y-2">
-            <Label htmlFor="max-file-size">
-              Taille maximum de fichier (MB)
-            </Label>
+            <Label htmlFor="max-file-size">Taille maximum de fichier (MB)</Label>
             <Input
               id="max-file-size"
               type="number"
               min="1"
-              value={(customizationData?.settings?.limits as Record<string, any>)?.maxFileSizeMB || 10}
-              onChange={(e) => {
+              value={settings.limits?.maxFileSizeMB || 10}
+              onChange={e => {
                 save('settings', {
-                  ...customizationData?.settings,
+                  ...settings,
                   limits: {
-                    ...customizationData?.settings?.limits,
+                    ...settings.limits,
                     maxFileSizeMB: parseInt(e.target.value) || 10,
                   },
                 });
@@ -446,10 +328,3 @@ export const PlatformSettingsSection = ({ onChange }: PlatformSettingsSectionPro
     </div>
   );
 };
-
-
-
-
-
-
-

--- a/src/hooks/admin/usePlatformCustomization.tsx
+++ b/src/hooks/admin/usePlatformCustomization.tsx
@@ -18,6 +18,7 @@ import { useToast } from '@/hooks/use-toast';
 import { logger } from '@/lib/logger';
 import { validateSection, validateCustomizationData } from '@/lib/schemas/platform-customization';
 import type { PlatformCustomizationSchemaType } from '@/lib/schemas/platform-customization';
+import { stripFinancialSettingsFromCustomizationSettings } from '@/lib/admin/customization-settings';
 import { stripIntegrationsTree } from '@/lib/admin/integration-secrets';
 
 // Types pour les structures flexibles (emails, notifications, etc.)
@@ -343,10 +344,16 @@ function usePlatformCustomizationState() {
         // Utiliser le ref pour avoir les données les plus récentes
         const currentData = customizationDataRef.current;
 
-        const sectionPayload =
+        let sectionPayload: unknown =
           section === 'integrations' && data && typeof data === 'object'
             ? stripIntegrationsTree(data as Record<string, unknown>)
             : data;
+
+        if (section === 'settings' && sectionPayload && typeof sectionPayload === 'object') {
+          sectionPayload = stripFinancialSettingsFromCustomizationSettings(
+            sectionPayload as Record<string, unknown>
+          );
+        }
 
         // Fusionner les données existantes avec les nouvelles
         const updatedData = {
@@ -469,9 +476,17 @@ function usePlatformCustomizationState() {
 
       // Utiliser le ref pour avoir les données les plus récentes
       const currentData = customizationDataRef.current;
+      const dataToValidate = currentData?.settings
+        ? {
+            ...currentData,
+            settings: stripFinancialSettingsFromCustomizationSettings(
+              currentData.settings as Record<string, unknown>
+            ),
+          }
+        : currentData;
 
       // Valider toutes les données avant sauvegarde
-      const validation = validateCustomizationData(currentData);
+      const validation = validateCustomizationData(dataToValidate);
       if (!validation.valid) {
         const errorMessages = validation.errors.map(e => {
           const fieldName = e.path || 'champ inconnu';

--- a/src/hooks/usePlatformSettingsDirect.ts
+++ b/src/hooks/usePlatformSettingsDirect.ts
@@ -7,7 +7,10 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { logger } from '@/lib/logger';
 
-const PLATFORM_SETTINGS_FIELDS = 'id, platform_commission_rate, referral_commission_rate, min_withdrawal_amount, auto_approve_withdrawals, email_notifications, sms_notifications, created_at, updated_at, updated_by';
+export const PLATFORM_SETTINGS_SINGLETON_ID = '00000000-0000-0000-0000-000000000001';
+
+const PLATFORM_SETTINGS_FIELDS =
+  'id, platform_commission_rate, referral_commission_rate, min_withdrawal_amount, auto_approve_withdrawals, email_notifications, sms_notifications, created_at, updated_at, updated_by';
 
 export interface PlatformSettings {
   id: string;
@@ -50,7 +53,7 @@ export const usePlatformSettingsDirect = () => {
       const { data, error } = await supabase
         .from('platform_settings')
         .select(PLATFORM_SETTINGS_FIELDS)
-        .limit(1)
+        .eq('id', PLATFORM_SETTINGS_SINGLETON_ID)
         .single();
 
       if (error) {
@@ -67,7 +70,9 @@ export const usePlatformSettingsDirect = () => {
   const updateSettings = useMutation({
     mutationFn: async (updates: PlatformSettingsUpdate) => {
       // Récupérer l'utilisateur actuel
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
 
       const { data, error } = await supabase
         .from('platform_settings')
@@ -76,7 +81,7 @@ export const usePlatformSettingsDirect = () => {
           updated_by: user?.id,
           updated_at: new Date().toISOString(),
         })
-        .eq('id', '00000000-0000-0000-0000-000000000001') // Singleton ID
+        .eq('id', PLATFORM_SETTINGS_SINGLETON_ID)
         .select()
         .single();
 
@@ -87,7 +92,7 @@ export const usePlatformSettingsDirect = () => {
 
       return data as PlatformSettings;
     },
-    onSuccess: (data) => {
+    onSuccess: data => {
       queryClient.setQueryData(['platform-settings'], data);
       queryClient.invalidateQueries({ queryKey: ['platform-settings'] });
       toast({
@@ -115,16 +120,3 @@ export const usePlatformSettingsDirect = () => {
     isUpdating: updateSettings.isPending,
   };
 };
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/lib/admin/__tests__/admin-route-permissions.test.ts
+++ b/src/lib/admin/__tests__/admin-route-permissions.test.ts
@@ -30,4 +30,13 @@ describe('admin-route-permissions', () => {
     expect(getAdminRouteAccess('/admin/security')?.permissions).toBeUndefined();
     expect(canAccessAdminPath('/admin/security', can, false)).toBe(true);
   });
+
+  it('newsletter route requires settings.manage', () => {
+    expect(getAdminRouteAccess('/admin/newsletter-subscribers')?.permissions).toEqual([
+      'settings.manage',
+    ]);
+    expect(canAccessAdminPath('/admin/newsletter-subscribers', can, false)).toBe(false);
+    const canSettings = (key: string) => key === 'settings.manage';
+    expect(canAccessAdminPath('/admin/newsletter-subscribers', canSettings, false)).toBe(true);
+  });
 });

--- a/src/lib/admin/__tests__/customization-settings.test.ts
+++ b/src/lib/admin/__tests__/customization-settings.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { stripFinancialSettingsFromCustomizationSettings } from '@/lib/admin/customization-settings';
+
+describe('stripFinancialSettingsFromCustomizationSettings', () => {
+  it('removes commissions and withdrawals from settings JSON', () => {
+    const result = stripFinancialSettingsFromCustomizationSettings({
+      commissions: { platformRate: 10, referralRate: 2 },
+      withdrawals: { minAmount: 5000, autoApprove: true },
+      limits: { maxProducts: 100, maxStores: 5 },
+    });
+
+    expect(result).toEqual({
+      limits: { maxProducts: 100, maxStores: 5 },
+    });
+  });
+
+  it('returns empty object for undefined input', () => {
+    expect(stripFinancialSettingsFromCustomizationSettings(undefined)).toEqual({});
+  });
+});

--- a/src/lib/admin/admin-nav.ts
+++ b/src/lib/admin/admin-nav.ts
@@ -51,6 +51,7 @@ import {
   Globe,
   Zap,
   LayoutGrid,
+  Mail,
 } from 'lucide-react';
 
 export type AdminNavItem = {
@@ -460,6 +461,12 @@ export const ADMIN_NAV_SECTIONS: AdminNavSection[] = [
         icon: Sparkles,
         label: 'Personnalisation',
         path: '/admin/platform-customization',
+        permissions: ['settings.manage'],
+      },
+      {
+        icon: Mail,
+        label: 'Newsletter',
+        path: '/admin/newsletter-subscribers',
         permissions: ['settings.manage'],
       },
     ],

--- a/src/lib/admin/customization-settings.ts
+++ b/src/lib/admin/customization-settings.ts
@@ -1,0 +1,11 @@
+/**
+ * Commissions et retraits sont stockés dans platform_settings (singleton colonnes).
+ * Ne pas les dupliquer dans customization.settings (JSON).
+ */
+export function stripFinancialSettingsFromCustomizationSettings(
+  settings: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!settings || typeof settings !== 'object') return {};
+  const { commissions: _c, withdrawals: _w, ...rest } = settings;
+  return rest;
+}

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { usePlatformSettings } from '@/hooks/usePlatformSettings';
-import { Settings, Save, Info, Loader2, AlertCircle } from 'lucide-react';
+import { usePlatformSettingsDirect } from '@/hooks/usePlatformSettingsDirect';
+import { Settings, Save, Info, Loader2, AlertCircle, Percent, ArrowRight } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAdminPermissions, DEFAULT_PERMISSION_KEYS } from '@/hooks/useAdminPermissions';
@@ -18,7 +20,13 @@ import { Shield } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 
 const AdminSettings = () => {
-  const { settings: dbSettings, loading, error, updateSettings } = usePlatformSettings();
+  const { settings: dbSettings, loading, error } = usePlatformSettings();
+  const {
+    settings: platformSettings,
+    isLoading: platformSettingsLoading,
+    updateSettings: updatePlatformSettings,
+    isUpdating: isPlatformSettingsUpdating,
+  } = usePlatformSettingsDirect();
   const {
     roles,
     loading: rolesLoading,
@@ -51,54 +59,30 @@ const AdminSettings = () => {
   const normalizePermissions = (input: unknown): Record<string, boolean> => {
     if (!input || typeof input !== 'object') return {};
     const obj = input as Record<string, unknown>;
-    const  out: Record<string, boolean> = {};
+    const out: Record<string, boolean> = {};
     for (const [k, v] of Object.entries(obj)) out[k] = Boolean(v);
     return out;
   };
 
-  // État local pour le formulaire
-  const [localSettings, setLocalSettings] = useState({
-    platformCommissionRate: 10,
-    referralCommissionRate: 2,
-    minWithdrawalAmount: 10000,
-    autoApproveWithdrawals: false,
-    emailNotifications: true,
-    smsNotifications: false,
-  });
+  const [emailNotifications, setEmailNotifications] = useState(true);
+  const [smsNotifications, setSmsNotifications] = useState(false);
 
-  const [isSaving, setIsSaving] = useState(false);
-
-  // Synchroniser l'état local avec les paramètres chargés depuis la DB
   useEffect(() => {
-    if (dbSettings) {
-      setLocalSettings({
-        platformCommissionRate: dbSettings.platform_commission_rate,
-        referralCommissionRate: dbSettings.referral_commission_rate,
-        minWithdrawalAmount: dbSettings.min_withdrawal_amount,
-        autoApproveWithdrawals: dbSettings.auto_approve_withdrawals,
-        emailNotifications: dbSettings.email_notifications,
-        smsNotifications: dbSettings.sms_notifications,
-      });
+    if (platformSettings) {
+      setEmailNotifications(platformSettings.email_notifications);
+      setSmsNotifications(platformSettings.sms_notifications);
     }
-  }, [dbSettings]);
+  }, [platformSettings]);
 
-  const handleSave = async () => {
-    setIsSaving(true);
-
-    await updateSettings({
-      platform_commission_rate: localSettings.platformCommissionRate,
-      referral_commission_rate: localSettings.referralCommissionRate,
-      min_withdrawal_amount: localSettings.minWithdrawalAmount,
-      auto_approve_withdrawals: localSettings.autoApproveWithdrawals,
-      email_notifications: localSettings.emailNotifications,
-      sms_notifications: localSettings.smsNotifications,
+  const handleSaveNotifications = () => {
+    updatePlatformSettings({
+      email_notifications: emailNotifications,
+      sms_notifications: smsNotifications,
     });
-
-    setIsSaving(false);
   };
 
   // Loading state
-  if (loading) {
+  if (loading || platformSettingsLoading) {
     return (
       <AdminLayout>
         <div className="container mx-auto p-6 space-y-6">
@@ -143,116 +127,31 @@ const AdminSettings = () => {
           <Settings className="h-8 w-8 text-muted-foreground" />
         </div>
 
-        {/* Commission Settings */}
-        {can('users.roles') && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Taux de commission</CardTitle>
-              <CardDescription>Configurer les commissions de la plateforme</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="space-y-2">
-                <Label htmlFor="platformCommission">Commission Plateforme (%)</Label>
-                <Input
-                  id="platformCommission"
-                  type="number"
-                  value={localSettings.platformCommissionRate}
-                  onChange={e =>
-                    setLocalSettings({
-                      ...localSettings,
-                      platformCommissionRate: Number(e.target.value),
-                    })
-                  }
-                  min="0"
-                  max="100"
-                  step="0.01"
-                  className="min-h-[44px]"
-                />
-                <p className="text-sm text-muted-foreground">
-                  Commission prélevée sur chaque vente
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="referralCommission">Commission Parrainage (%)</Label>
-                <Input
-                  id="referralCommission"
-                  type="number"
-                  value={localSettings.referralCommissionRate}
-                  onChange={e =>
-                    setLocalSettings({
-                      ...localSettings,
-                      referralCommissionRate: Number(e.target.value),
-                    })
-                  }
-                  min="0"
-                  max="100"
-                  step="0.01"
-                  className="min-h-[44px]"
-                />
-                <p className="text-sm text-muted-foreground">
-                  Commission versée au parrain sur les ventes du filleul
-                </p>
-              </div>
-
-              <Alert>
-                <Info className="h-4 w-4" />
-                <AlertDescription>
-                  Les modifications des taux s'appliquent uniquement aux nouvelles transactions.
-                </AlertDescription>
-              </Alert>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Withdrawal Settings */}
+        {/* Commissions & retraits — source canonique */}
         <Card>
           <CardHeader>
-            <CardTitle>Paramètres de retrait</CardTitle>
-            <CardDescription>Configuration des retraits de fonds</CardDescription>
+            <CardTitle className="flex items-center gap-2">
+              <Percent className="h-5 w-5" />
+              Commissions et retraits
+            </CardTitle>
+            <CardDescription>
+              Taux de commission, parrainage et règles de retrait des vendeurs
+            </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="space-y-2">
-              <Label htmlFor="minWithdrawal">Montant minimum de retrait (XOF)</Label>
-              <Input
-                id="minWithdrawal"
-                type="number"
-                value={localSettings.minWithdrawalAmount}
-                onChange={e =>
-                  setLocalSettings({
-                    ...localSettings,
-                    minWithdrawalAmount: Number(e.target.value),
-                  })
-                }
-                min="0"
-                step="1"
-                className="min-h-[44px]"
-              />
-              <p className="text-sm text-muted-foreground">
-                Montant minimum requis pour effectuer un retrait
-              </p>
-            </div>
-
-            <div className="flex items-center justify-between">
-              <div className="space-y-0.5">
-                <Label>Approbation automatique</Label>
-                <p className="text-sm text-muted-foreground">
-                  Approuver automatiquement les demandes de retrait
-                </p>
-              </div>
-              <Button
-                variant={localSettings.autoApproveWithdrawals ? 'default' : 'outline'}
-                size="sm"
-                onClick={() =>
-                  setLocalSettings({
-                    ...localSettings,
-                    autoApproveWithdrawals: !localSettings.autoApproveWithdrawals,
-                  })
-                }
-              >
-                {localSettings.autoApproveWithdrawals ? 'Activé' : 'Désactivé'}
-              </Button>
-            </div>
+          <CardContent className="space-y-4">
+            <Alert>
+              <Info className="h-4 w-4" />
+              <AlertDescription>
+                Les paramètres financiers sont centralisés sur la page dédiée. Les modifications des
+                taux s&apos;appliquent uniquement aux nouvelles transactions.
+              </AlertDescription>
+            </Alert>
+            <Button asChild variant="outline" className="gap-2">
+              <Link to="/admin/commission-settings">
+                Ouvrir les paramètres de commission
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
           </CardContent>
         </Card>
 
@@ -271,16 +170,11 @@ const AdminSettings = () => {
                 </p>
               </div>
               <Button
-                variant={localSettings.emailNotifications ? 'default' : 'outline'}
+                variant={emailNotifications ? 'default' : 'outline'}
                 size="sm"
-                onClick={() =>
-                  setLocalSettings({
-                    ...localSettings,
-                    emailNotifications: !localSettings.emailNotifications,
-                  })
-                }
+                onClick={() => setEmailNotifications(prev => !prev)}
               >
-                {localSettings.emailNotifications ? 'Activé' : 'Désactivé'}
+                {emailNotifications ? 'Activé' : 'Désactivé'}
               </Button>
             </div>
 
@@ -292,16 +186,11 @@ const AdminSettings = () => {
                 </p>
               </div>
               <Button
-                variant={localSettings.smsNotifications ? 'default' : 'outline'}
+                variant={smsNotifications ? 'default' : 'outline'}
                 size="sm"
-                onClick={() =>
-                  setLocalSettings({
-                    ...localSettings,
-                    smsNotifications: !localSettings.smsNotifications,
-                  })
-                }
+                onClick={() => setSmsNotifications(prev => !prev)}
               >
-                {localSettings.smsNotifications ? 'Activé' : 'Désactivé'}
+                {smsNotifications ? 'Activé' : 'Désactivé'}
               </Button>
             </div>
           </CardContent>
@@ -605,8 +494,13 @@ const AdminSettings = () => {
 
         {/* Save Button */}
         <div className="flex justify-end">
-          <Button onClick={handleSave} size="lg" className="gap-2" disabled={isSaving}>
-            {isSaving ? (
+          <Button
+            onClick={handleSaveNotifications}
+            size="lg"
+            className="gap-2"
+            disabled={isPlatformSettingsUpdating}
+          >
+            {isPlatformSettingsUpdating ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
                 Sauvegarde en cours...
@@ -614,7 +508,7 @@ const AdminSettings = () => {
             ) : (
               <>
                 <Save className="h-4 w-4" />
-                Sauvegarder les paramètres
+                Sauvegarder les notifications
               </>
             )}
           </Button>
@@ -625,9 +519,3 @@ const AdminSettings = () => {
 };
 
 export default AdminSettings;
-
-
-
-
-
-

--- a/src/pages/admin/AdminWebhookManagement.tsx
+++ b/src/pages/admin/AdminWebhookManagement.tsx
@@ -10,8 +10,12 @@
  * - Statistiques
  */
 
+import { useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/AppSidebar';
+import { AdminLayout } from '@/components/admin/AdminLayout';
+import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -81,7 +85,7 @@ import {
   Eye,
   ExternalLink,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { useToast } from '@/hooks/use-toast';
@@ -158,11 +162,62 @@ const WEBHOOK_EVENTS: { category: string; events: { value: WebhookEventType; lab
     },
   ];
 
+type AdminStoreOption = { id: string; name: string; slug: string | null };
+
+function WebhookPageShell({ adminMode, children }: { adminMode: boolean; children: ReactNode }) {
+  if (adminMode) {
+    return (
+      <AdminLayout>
+        <div className="space-y-4 sm:space-y-6">{children}</div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <SidebarProvider>
+      <div className="flex min-h-screen w-full overflow-x-hidden">
+        <AppSidebar />
+        <div className="flex-1 flex flex-col">
+          <main className="flex-1 overflow-auto pb-16 md:pb-0">
+            <div className="container mx-auto p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6">
+              {children}
+            </div>
+          </main>
+        </div>
+      </div>
+    </SidebarProvider>
+  );
+}
+
 export default function AdminWebhookManagement() {
   const isMobile = useIsMobile();
-  const { store, loading: storeLoading } = useStore();
-  const { data: webhooks, isLoading } = useWebhooks(store?.id);
-  const { data: stats } = useWebhookStats(store?.id);
+  const location = useLocation();
+  const isPlatformAdminView = location.pathname.startsWith('/admin/webhooks');
+  const { store: vendorStore, loading: vendorStoreLoading } = useStore();
+  const [selectedAdminStoreId, setSelectedAdminStoreId] = useState('');
+
+  const { data: adminStores, isLoading: adminStoresLoading } = useQuery({
+    queryKey: ['admin-webhook-stores'],
+    queryFn: async () => {
+      const { data, error } = await supabase.from('stores').select('id, name, slug').order('name');
+      if (error) throw error;
+      return (data ?? []) as AdminStoreOption[];
+    },
+    enabled: isPlatformAdminView,
+  });
+
+  useEffect(() => {
+    if (!isPlatformAdminView || !adminStores?.length) return;
+    if (!selectedAdminStoreId || !adminStores.some(s => s.id === selectedAdminStoreId)) {
+      setSelectedAdminStoreId(adminStores[0].id);
+    }
+  }, [isPlatformAdminView, adminStores, selectedAdminStoreId]);
+
+  const effectiveStoreId = isPlatformAdminView ? selectedAdminStoreId : vendorStore?.id;
+  const storeLoading = isPlatformAdminView ? adminStoresLoading : vendorStoreLoading;
+
+  const { data: webhooks, isLoading } = useWebhooks(effectiveStoreId);
+  const { data: stats } = useWebhookStats(effectiveStoreId);
   const createWebhook = useCreateWebhook();
   const updateWebhook = useUpdateWebhook();
   const deleteWebhook = useDeleteWebhook();
@@ -245,7 +300,7 @@ export default function AdminWebhookManagement() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!store?.id) return;
+    if (!effectiveStoreId) return;
 
     try {
       if (editingWebhook) {
@@ -256,7 +311,7 @@ export default function AdminWebhookManagement() {
       } else {
         await createWebhook.mutateAsync({
           ...formData,
-          store_id: store.id,
+          store_id: effectiveStoreId,
         });
       }
       setIsDialogOpen(false);
@@ -325,1040 +380,1015 @@ export default function AdminWebhookManagement() {
 
   if (storeLoading || isLoading) {
     return (
-      <SidebarProvider>
-        <div className="flex min-h-screen w-full overflow-x-hidden">
-          <AppSidebar />
-          <div className="flex-1 flex flex-col">
-            <main className="flex-1 overflow-auto pb-16 md:pb-0">
-              <div className="container mx-auto p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6">
-                <Skeleton className="h-8 sm:h-10 w-48 sm:w-64" />
-                <Skeleton className="h-64 w-full" />
-              </div>
-            </main>
-          </div>
-        </div>
-      </SidebarProvider>
+      <WebhookPageShell adminMode={isPlatformAdminView}>
+        <Skeleton className="h-8 sm:h-10 w-48 sm:w-64" />
+        <Skeleton className="h-64 w-full" />
+      </WebhookPageShell>
     );
   }
 
-  if (!store) {
+  if (isPlatformAdminView && !adminStores?.length) {
     return (
-      <SidebarProvider>
-        <div className="flex min-h-screen w-full overflow-x-hidden">
-          <AppSidebar />
-          <div className="flex-1 flex flex-col">
-            <main className="flex-1 overflow-auto pb-16 md:pb-0">
-              <div className="container mx-auto p-3 sm:p-4 lg:p-6">
-                <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
-                  <CardContent className="pt-6">
-                    <Alert>
-                      <AlertCircle className="h-4 w-4" />
-                      <AlertDescription className="text-xs sm:text-sm">
-                        Veuillez d'abord créer une boutique.
-                      </AlertDescription>
-                    </Alert>
-                  </CardContent>
-                </Card>
-              </div>
-            </main>
-          </div>
-        </div>
-      </SidebarProvider>
+      <WebhookPageShell adminMode>
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardContent className="pt-6">
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription className="text-xs sm:text-sm">
+                Aucune boutique disponible sur la plateforme.
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </WebhookPageShell>
+    );
+  }
+
+  if (!isPlatformAdminView && !vendorStore) {
+    return (
+      <WebhookPageShell adminMode={false}>
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardContent className="pt-6">
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription className="text-xs sm:text-sm">
+                Veuillez d'abord créer une boutique.
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </WebhookPageShell>
     );
   }
 
   return (
-    <SidebarProvider>
-      <div className="flex min-h-screen w-full overflow-x-hidden">
-        <AppSidebar />
-        <div className="flex-1 flex flex-col">
-          <main className="flex-1 overflow-auto pb-16 md:pb-0">
-            <div className="container mx-auto p-3 sm:p-4 lg:p-6 space-y-4 sm:space-y-6">
-              {/* Header - Responsive & Animated */}
-              <div
-                ref={headerRef}
-                className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 animate-in fade-in slide-in-from-top-4 duration-700"
-              >
+    <WebhookPageShell adminMode={isPlatformAdminView}>
+      {isPlatformAdminView && adminStores && adminStores.length > 0 && (
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardContent className="pt-6 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
+            <div className="space-y-1 flex-1">
+              <Label htmlFor="admin-webhook-store">Boutique</Label>
+              <p className="text-xs text-muted-foreground">
+                Sélectionnez la boutique dont vous gérez les webhooks
+              </p>
+            </div>
+            <Select value={selectedAdminStoreId} onValueChange={setSelectedAdminStoreId}>
+              <SelectTrigger id="admin-webhook-store" className="w-full sm:w-72 min-h-[44px]">
+                <SelectValue placeholder="Choisir une boutique" />
+              </SelectTrigger>
+              <SelectContent>
+                {adminStores.map(store => (
+                  <SelectItem key={store.id} value={store.id}>
+                    {store.name}
+                    {store.slug ? ` (@${store.slug})` : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Header - Responsive & Animated */}
+      <div
+        ref={headerRef}
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 animate-in fade-in slide-in-from-top-4 duration-700"
+      >
+        <div>
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold flex items-center gap-2 mb-1 sm:mb-2">
+            <div className="p-2 rounded-lg bg-gradient-to-br from-purple-500/10 to-pink-500/5 backdrop-blur-sm border border-purple-500/20 animate-in zoom-in duration-500">
+              <WebhookIcon
+                className="h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 text-purple-500 dark:text-purple-400"
+                aria-hidden="true"
+              />
+            </div>
+            <span className="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+              Gestion des Webhooks
+            </span>
+          </h1>
+          <p className="text-xs sm:text-sm lg:text-base text-muted-foreground">
+            Configurez des webhooks pour recevoir des notifications en temps réel
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            onSelect={() => handleOpenDialog()}
+            className="min-h-[44px] h-11 sm:h-12 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
+          >
+            <Plus className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1.5 sm:mr-2" />
+            <span className="hidden sm:inline text-xs sm:text-sm">Nouveau Webhook</span>
+            <span className="sm:hidden text-xs">Nouveau</span>
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      {stats && (
+        <div
+          ref={statsRef}
+          className="grid gap-3 sm:gap-4 grid-cols-2 sm:grid-cols-4 animate-in fade-in slide-in-from-bottom-4 duration-700"
+        >
+          <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+            <CardContent className="p-3 sm:p-4">
+              <div className="flex items-center justify-between">
                 <div>
-                  <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold flex items-center gap-2 mb-1 sm:mb-2">
-                    <div className="p-2 rounded-lg bg-gradient-to-br from-purple-500/10 to-pink-500/5 backdrop-blur-sm border border-purple-500/20 animate-in zoom-in duration-500">
-                      <WebhookIcon
-                        className="h-5 w-5 sm:h-6 sm:w-6 lg:h-8 lg:w-8 text-purple-500 dark:text-purple-400"
-                        aria-hidden="true"
-                      />
-                    </div>
-                    <span className="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
-                      Gestion des Webhooks
-                    </span>
-                  </h1>
-                  <p className="text-xs sm:text-sm lg:text-base text-muted-foreground">
-                    Configurez des webhooks pour recevoir des notifications en temps réel
+                  <p className="text-xs sm:text-sm text-muted-foreground mb-1">Webhooks Actifs</p>
+                  <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
+                    {stats.active_webhooks}
                   </p>
                 </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    onSelect={() => handleOpenDialog()}
-                    className="min-h-[44px] h-11 sm:h-12 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
-                  >
-                    <Plus className="h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1.5 sm:mr-2" />
-                    <span className="hidden sm:inline text-xs sm:text-sm">Nouveau Webhook</span>
-                    <span className="sm:hidden text-xs">Nouveau</span>
-                  </Button>
+                <div className="p-2 rounded-lg bg-gradient-to-br from-purple-500/10 to-pink-500/5">
+                  <Activity className="h-4 w-4 sm:h-5 sm:w-5 text-purple-500" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+            <CardContent className="p-3 sm:p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs sm:text-sm text-muted-foreground mb-1">Livraisons Total</p>
+                  <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent">
+                    {stats.total_deliveries}
+                  </p>
+                </div>
+                <div className="p-2 rounded-lg bg-gradient-to-br from-blue-500/10 to-cyan-500/5">
+                  <CheckCircle className="h-4 w-4 sm:h-5 sm:w-5 text-blue-500" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+            <CardContent className="p-3 sm:p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs sm:text-sm text-muted-foreground mb-1">Taux de Réussite</p>
+                  <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
+                    {stats.success_rate}%
+                  </p>
+                </div>
+                <div className="p-2 rounded-lg bg-gradient-to-br from-green-500/10 to-emerald-500/5">
+                  <CheckCircle className="h-4 w-4 sm:h-5 sm:w-5 text-green-500" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
+            <CardContent className="p-3 sm:p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs sm:text-sm text-muted-foreground mb-1">Échecs</p>
+                  <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-red-600 to-orange-600 bg-clip-text text-transparent">
+                    {stats.failed_deliveries}
+                  </p>
+                </div>
+                <div className="p-2 rounded-lg bg-gradient-to-br from-red-500/10 to-orange-500/5">
+                  <XCircle className="h-4 w-4 sm:h-5 sm:w-5 text-red-500" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Search */}
+      <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+        <CardContent className="pt-4 sm:pt-6">
+          <div className="relative flex items-center">
+            <Search className="absolute left-2.5 h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />
+            <Input
+              placeholder="Rechercher un webhook..."
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              className="pl-8 pr-8 min-h-[44px] h-11 sm:h-12 text-xs sm:text-sm flex-1"
+            />
+            {searchQuery && (
+              <button
+                onSelect={() => setSearchQuery('')}
+                className="absolute right-2.5 text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+              </button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Webhooks Table */}
+      <Card
+        ref={listRef}
+        className="border-border/50 bg-card/50 backdrop-blur-sm animate-in fade-in slide-in-from-bottom-4 duration-700"
+      >
+        <CardHeader>
+          <CardTitle className="text-base sm:text-lg">Webhooks</CardTitle>
+          <CardDescription className="text-xs sm:text-sm">
+            {filteredWebhooks?.length || 0} webhook(s) configuré(s)
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {filteredWebhooks && filteredWebhooks.length > 0 ? (
+            <>
+              {/* Desktop Table View */}
+              <div className="hidden lg:block">
+                <div className="border border-border/50 rounded-lg overflow-hidden">
+                  <Table>
+                    <TableHeader>
+                      <TableRow className="bg-muted/50">
+                        <TableHead className="text-xs sm:text-sm font-semibold">Nom</TableHead>
+                        <TableHead className="text-xs sm:text-sm font-semibold">URL</TableHead>
+                        <TableHead className="text-xs sm:text-sm font-semibold">
+                          Événements
+                        </TableHead>
+                        <TableHead className="text-xs sm:text-sm font-semibold">Statut</TableHead>
+                        <TableHead className="text-xs sm:text-sm font-semibold">
+                          Statistiques
+                        </TableHead>
+                        <TableHead className="text-xs sm:text-sm font-semibold">
+                          Dernière livraison
+                        </TableHead>
+                        <TableHead className="text-right text-xs sm:text-sm font-semibold">
+                          Actions
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredWebhooks.map(webhook => (
+                        <TableRow key={webhook.id} className="hover:bg-muted/50 transition-colors">
+                          <TableCell className="font-medium text-xs sm:text-sm">
+                            {webhook.name}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-2 max-w-xs">
+                              <code className="text-xs bg-muted/50 px-2 py-1 rounded truncate font-mono">
+                                {webhook.url}
+                              </code>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline" className="text-xs">
+                              {webhook.events.length} événement(s)
+                            </Badge>
+                          </TableCell>
+                          <TableCell>{getStatusBadge(webhook.status)}</TableCell>
+                          <TableCell>
+                            <div className="text-xs text-muted-foreground">
+                              <div>✓ {webhook.successful_deliveries} réussies</div>
+                              <div>✗ {webhook.failed_deliveries} échecs</div>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            {webhook.last_triggered_at ? (
+                              <span className="text-xs text-muted-foreground">
+                                {format(new Date(webhook.last_triggered_at), 'PPp', {
+                                  locale: fr,
+                                })}
+                              </span>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">Jamais</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-2">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onSelect={() => {
+                                  setSelectedWebhookId(webhook.id);
+                                }}
+                                className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
+                              >
+                                <Activity className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onSelect={() => handleTest(webhook)}
+                                disabled={testWebhook.isPending}
+                                className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
+                              >
+                                <TestTube className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onSelect={() => handleOpenDialog(webhook)}
+                                className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
+                              >
+                                <Edit className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onSelect={() => handleDelete(webhook)}
+                                disabled={deleteWebhook.isPending}
+                                className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
+                              >
+                                <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
                 </div>
               </div>
 
-              {/* Stats */}
-              {stats && (
-                <div
-                  ref={statsRef}
-                  className="grid gap-3 sm:gap-4 grid-cols-2 sm:grid-cols-4 animate-in fade-in slide-in-from-bottom-4 duration-700"
-                >
-                  <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-                    <CardContent className="p-3 sm:p-4">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <p className="text-xs sm:text-sm text-muted-foreground mb-1">
-                            Webhooks Actifs
-                          </p>
-                          <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
-                            {stats.active_webhooks}
-                          </p>
+              {/* Mobile Table Card View */}
+              {isMobile ? (
+                <MobileTableCard
+                  data={filteredWebhooks.map(w => ({ ...w, id: w.id }))}
+                  columns={[
+                    {
+                      key: 'name',
+                      label: 'Nom',
+                      priority: 'high',
+                      render: (_value, row) => (
+                        <span className="font-semibold text-sm">
+                          {(row as unknown as Webhook).name}
+                        </span>
+                      ),
+                    },
+                    {
+                      key: 'url',
+                      label: 'URL',
+                      priority: 'high',
+                      render: (_value, row) => (
+                        <code className="text-xs bg-muted/50 px-2 py-1 rounded truncate max-w-full font-mono block">
+                          {(row as unknown as Webhook).url}
+                        </code>
+                      ),
+                    },
+                    {
+                      key: 'events',
+                      label: 'Événements',
+                      priority: 'medium',
+                      render: (_value, row) => (
+                        <Badge variant="outline" className="text-xs">
+                          {(row as unknown as Webhook).events.length} événement(s)
+                        </Badge>
+                      ),
+                    },
+                    {
+                      key: 'status',
+                      label: 'Statut',
+                      priority: 'high',
+                      render: (_value, row) => getStatusBadge((row as unknown as Webhook).status),
+                    },
+                    {
+                      key: 'stats',
+                      label: 'Statistiques',
+                      priority: 'medium',
+                      render: (_value, row) => (
+                        <div className="text-xs text-muted-foreground">
+                          <div>✓ {(row as unknown as Webhook).successful_deliveries} réussies</div>
+                          <div>✗ {(row as unknown as Webhook).failed_deliveries} échecs</div>
                         </div>
-                        <div className="p-2 rounded-lg bg-gradient-to-br from-purple-500/10 to-pink-500/5">
-                          <Activity className="h-4 w-4 sm:h-5 sm:w-5 text-purple-500" />
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                  <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-                    <CardContent className="p-3 sm:p-4">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <p className="text-xs sm:text-sm text-muted-foreground mb-1">
-                            Livraisons Total
-                          </p>
-                          <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text text-transparent">
-                            {stats.total_deliveries}
-                          </p>
-                        </div>
-                        <div className="p-2 rounded-lg bg-gradient-to-br from-blue-500/10 to-cyan-500/5">
-                          <CheckCircle className="h-4 w-4 sm:h-5 sm:w-5 text-blue-500" />
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                  <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-                    <CardContent className="p-3 sm:p-4">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <p className="text-xs sm:text-sm text-muted-foreground mb-1">
-                            Taux de Réussite
-                          </p>
-                          <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
-                            {stats.success_rate}%
-                          </p>
-                        </div>
-                        <div className="p-2 rounded-lg bg-gradient-to-br from-green-500/10 to-emerald-500/5">
-                          <CheckCircle className="h-4 w-4 sm:h-5 sm:w-5 text-green-500" />
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                  <Card className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300 hover:scale-[1.02]">
-                    <CardContent className="p-3 sm:p-4">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <p className="text-xs sm:text-sm text-muted-foreground mb-1">Échecs</p>
-                          <p className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-red-600 to-orange-600 bg-clip-text text-transparent">
-                            {stats.failed_deliveries}
-                          </p>
-                        </div>
-                        <div className="p-2 rounded-lg bg-gradient-to-br from-red-500/10 to-orange-500/5">
-                          <XCircle className="h-4 w-4 sm:h-5 sm:w-5 text-red-500" />
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </div>
-              )}
-
-              {/* Search */}
-              <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
-                <CardContent className="pt-4 sm:pt-6">
-                  <div className="relative flex items-center">
-                    <Search className="absolute left-2.5 h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />
-                    <Input
-                      placeholder="Rechercher un webhook..."
-                      value={searchQuery}
-                      onChange={e => setSearchQuery(e.target.value)}
-                      className="pl-8 pr-8 min-h-[44px] h-11 sm:h-12 text-xs sm:text-sm flex-1"
-                    />
-                    {searchQuery && (
-                      <button
-                        onSelect={() => setSearchQuery('')}
-                        className="absolute right-2.5 text-muted-foreground hover:text-foreground"
+                      ),
+                    },
+                    {
+                      key: 'last_triggered',
+                      label: 'Dernière livraison',
+                      priority: 'low',
+                      render: (_value, row) => (
+                        <span className="text-xs text-muted-foreground">
+                          {(row as unknown as Webhook).last_triggered_at
+                            ? format(
+                                new Date((row as unknown as Webhook).last_triggered_at!),
+                                'PPp',
+                                { locale: fr }
+                              )
+                            : 'Jamais'}
+                        </span>
+                      ),
+                    },
+                  ]}
+                  actions={row => (
+                    <div className="flex flex-col gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onSelect={() => setSelectedWebhookId((row as unknown as Webhook).id)}
+                        className="min-h-[44px] w-full"
                       >
-                        <X className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
-                      </button>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Webhooks Table */}
-              <Card
-                ref={listRef}
-                className="border-border/50 bg-card/50 backdrop-blur-sm animate-in fade-in slide-in-from-bottom-4 duration-700"
-              >
-                <CardHeader>
-                  <CardTitle className="text-base sm:text-lg">Webhooks</CardTitle>
-                  <CardDescription className="text-xs sm:text-sm">
-                    {filteredWebhooks?.length || 0} webhook(s) configuré(s)
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  {filteredWebhooks && filteredWebhooks.length > 0 ? (
-                    <>
-                      {/* Desktop Table View */}
-                      <div className="hidden lg:block">
-                        <div className="border border-border/50 rounded-lg overflow-hidden">
-                          <Table>
-                            <TableHeader>
-                              <TableRow className="bg-muted/50">
-                                <TableHead className="text-xs sm:text-sm font-semibold">
-                                  Nom
-                                </TableHead>
-                                <TableHead className="text-xs sm:text-sm font-semibold">
-                                  URL
-                                </TableHead>
-                                <TableHead className="text-xs sm:text-sm font-semibold">
-                                  Événements
-                                </TableHead>
-                                <TableHead className="text-xs sm:text-sm font-semibold">
-                                  Statut
-                                </TableHead>
-                                <TableHead className="text-xs sm:text-sm font-semibold">
-                                  Statistiques
-                                </TableHead>
-                                <TableHead className="text-xs sm:text-sm font-semibold">
-                                  Dernière livraison
-                                </TableHead>
-                                <TableHead className="text-right text-xs sm:text-sm font-semibold">
-                                  Actions
-                                </TableHead>
-                              </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                              {filteredWebhooks.map(webhook => (
-                                <TableRow
-                                  key={webhook.id}
-                                  className="hover:bg-muted/50 transition-colors"
-                                >
-                                  <TableCell className="font-medium text-xs sm:text-sm">
-                                    {webhook.name}
-                                  </TableCell>
-                                  <TableCell>
-                                    <div className="flex items-center gap-2 max-w-xs">
-                                      <code className="text-xs bg-muted/50 px-2 py-1 rounded truncate font-mono">
-                                        {webhook.url}
-                                      </code>
-                                    </div>
-                                  </TableCell>
-                                  <TableCell>
-                                    <Badge variant="outline" className="text-xs">
-                                      {webhook.events.length} événement(s)
-                                    </Badge>
-                                  </TableCell>
-                                  <TableCell>{getStatusBadge(webhook.status)}</TableCell>
-                                  <TableCell>
-                                    <div className="text-xs text-muted-foreground">
-                                      <div>✓ {webhook.successful_deliveries} réussies</div>
-                                      <div>✗ {webhook.failed_deliveries} échecs</div>
-                                    </div>
-                                  </TableCell>
-                                  <TableCell>
-                                    {webhook.last_triggered_at ? (
-                                      <span className="text-xs text-muted-foreground">
-                                        {format(new Date(webhook.last_triggered_at), 'PPp', {
-                                          locale: fr,
-                                        })}
-                                      </span>
-                                    ) : (
-                                      <span className="text-xs text-muted-foreground">Jamais</span>
-                                    )}
-                                  </TableCell>
-                                  <TableCell className="text-right">
-                                    <div className="flex items-center justify-end gap-2">
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onSelect={() => {
-                                          setSelectedWebhookId(webhook.id);
-                                        }}
-                                        className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
-                                      >
-                                        <Activity className="h-3.5 w-3.5" />
-                                      </Button>
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onSelect={() => handleTest(webhook)}
-                                        disabled={testWebhook.isPending}
-                                        className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
-                                      >
-                                        <TestTube className="h-3.5 w-3.5" />
-                                      </Button>
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onSelect={() => handleOpenDialog(webhook)}
-                                        className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
-                                      >
-                                        <Edit className="h-3.5 w-3.5" />
-                                      </Button>
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onSelect={() => handleDelete(webhook)}
-                                        disabled={deleteWebhook.isPending}
-                                        className="min-h-[44px] min-w-[44px] h-11 w-11 p-0"
-                                      >
-                                        <Trash2 className="h-3.5 w-3.5 text-destructive" />
-                                      </Button>
-                                    </div>
-                                  </TableCell>
-                                </TableRow>
-                              ))}
-                            </TableBody>
-                          </Table>
-                        </div>
-                      </div>
-
-                      {/* Mobile Table Card View */}
-                      {isMobile ? (
-                        <MobileTableCard
-                          data={filteredWebhooks.map(w => ({ ...w, id: w.id }))}
-                          columns={[
-                            {
-                              key: 'name',
-                              label: 'Nom',
-                              priority: 'high',
-                              render: (_value, row) => (
-                                <span className="font-semibold text-sm">
-                                  {(row as unknown as Webhook).name}
-                                </span>
-                              ),
-                            },
-                            {
-                              key: 'url',
-                              label: 'URL',
-                              priority: 'high',
-                              render: (_value, row) => (
-                                <code className="text-xs bg-muted/50 px-2 py-1 rounded truncate max-w-full font-mono block">
-                                  {(row as unknown as Webhook).url}
-                                </code>
-                              ),
-                            },
-                            {
-                              key: 'events',
-                              label: 'Événements',
-                              priority: 'medium',
-                              render: (_value, row) => (
-                                <Badge variant="outline" className="text-xs">
-                                  {(row as unknown as Webhook).events.length} événement(s)
-                                </Badge>
-                              ),
-                            },
-                            {
-                              key: 'status',
-                              label: 'Statut',
-                              priority: 'high',
-                              render: (_value, row) =>
-                                getStatusBadge((row as unknown as Webhook).status),
-                            },
-                            {
-                              key: 'stats',
-                              label: 'Statistiques',
-                              priority: 'medium',
-                              render: (_value, row) => (
-                                <div className="text-xs text-muted-foreground">
-                                  <div>
-                                    ✓ {(row as unknown as Webhook).successful_deliveries} réussies
-                                  </div>
-                                  <div>
-                                    ✗ {(row as unknown as Webhook).failed_deliveries} échecs
-                                  </div>
-                                </div>
-                              ),
-                            },
-                            {
-                              key: 'last_triggered',
-                              label: 'Dernière livraison',
-                              priority: 'low',
-                              render: (_value, row) => (
-                                <span className="text-xs text-muted-foreground">
-                                  {(row as unknown as Webhook).last_triggered_at
-                                    ? format(
-                                        new Date((row as unknown as Webhook).last_triggered_at!),
-                                        'PPp',
-                                        { locale: fr }
-                                      )
-                                    : 'Jamais'}
-                                </span>
-                              ),
-                            },
-                          ]}
-                          actions={row => (
-                            <div className="flex flex-col gap-2">
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onSelect={() =>
-                                  setSelectedWebhookId((row as unknown as Webhook).id)
-                                }
-                                className="min-h-[44px] w-full"
+                        <Activity className="h-4 w-4 mr-2" />
+                        Historique
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onSelect={() => handleTest(row as unknown as Webhook)}
+                        disabled={testWebhook.isPending}
+                        className="min-h-[44px] w-full"
+                      >
+                        <TestTube className="h-4 w-4 mr-2" />
+                        Tester
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onSelect={() => handleOpenDialog(row as unknown as Webhook)}
+                        className="min-h-[44px] w-full"
+                      >
+                        <Edit className="h-4 w-4 mr-2" />
+                        Modifier
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onSelect={() => handleDelete(row as unknown as Webhook)}
+                        disabled={deleteWebhook.isPending}
+                        className="min-h-[44px] w-full text-destructive"
+                      >
+                        <Trash2 className="h-4 w-4 mr-2" />
+                        Supprimer
+                      </Button>
+                    </div>
+                  )}
+                />
+              ) : (
+                <div className="lg:hidden space-y-3 sm:space-y-4">
+                  {filteredWebhooks.map(webhook => (
+                    <Card
+                      key={webhook.id}
+                      className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300"
+                    >
+                      <CardContent className="p-4 sm:p-5">
+                        <div className="flex items-start justify-between mb-3">
+                          <div className="flex-1 min-w-0">
+                            <h3 className="font-semibold text-sm sm:text-base truncate mb-1">
+                              {webhook.name}
+                            </h3>
+                            <div className="flex items-center gap-2 mb-2">
+                              {getStatusBadge(webhook.status)}
+                              <Badge variant="outline" className="text-xs">
+                                {webhook.events.length} événement(s)
+                              </Badge>
+                            </div>
+                          </div>
+                          <Select>
+                            <SelectTrigger className="h-8 w-8">
+                              <MoreVertical className="h-4 w-4" aria-hidden="true" />
+                            </SelectTrigger>
+                            <SelectContent mobileVariant="sheet" className="min-w-[200px]">
+                              <SelectItem
+                                value="edit"
+                                onSelect={() => setSelectedWebhookId(webhook.id)}
                               >
                                 <Activity className="h-4 w-4 mr-2" />
                                 Historique
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onSelect={() => handleTest(row as unknown as Webhook)}
+                              </SelectItem>
+                              <SelectItem
+                                value="delete"
+                                onSelect={() => handleTest(webhook)}
                                 disabled={testWebhook.isPending}
-                                className="min-h-[44px] w-full"
                               >
                                 <TestTube className="h-4 w-4 mr-2" />
                                 Tester
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onSelect={() => handleOpenDialog(row as unknown as Webhook)}
-                                className="min-h-[44px] w-full"
-                              >
+                              </SelectItem>
+                              <SelectItem value="copy" onSelect={() => handleOpenDialog(webhook)}>
                                 <Edit className="h-4 w-4 mr-2" />
                                 Modifier
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onSelect={() => handleDelete(row as unknown as Webhook)}
+                              </SelectItem>
+                              <SelectItem
+                                value="view"
+                                onSelect={() => handleDelete(webhook)}
                                 disabled={deleteWebhook.isPending}
-                                className="min-h-[44px] w-full text-destructive"
+                                className="text-destructive"
                               >
                                 <Trash2 className="h-4 w-4 mr-2" />
                                 Supprimer
-                              </Button>
-                            </div>
-                          )}
-                        />
-                      ) : (
-                        <div className="lg:hidden space-y-3 sm:space-y-4">
-                          {filteredWebhooks.map(webhook => (
-                            <Card
-                              key={webhook.id}
-                              className="border-border/50 bg-card/50 backdrop-blur-sm hover:shadow-lg transition-all duration-300"
-                            >
-                              <CardContent className="p-4 sm:p-5">
-                                <div className="flex items-start justify-between mb-3">
-                                  <div className="flex-1 min-w-0">
-                                    <h3 className="font-semibold text-sm sm:text-base truncate mb-1">
-                                      {webhook.name}
-                                    </h3>
-                                    <div className="flex items-center gap-2 mb-2">
-                                      {getStatusBadge(webhook.status)}
-                                      <Badge variant="outline" className="text-xs">
-                                        {webhook.events.length} événement(s)
-                                      </Badge>
-                                    </div>
-                                  </div>
-                                  <Select>
-                                    <SelectTrigger className="h-8 w-8">
-                                      <MoreVertical className="h-4 w-4" aria-hidden="true" />
-                                    </SelectTrigger>
-                                    <SelectContent mobileVariant="sheet" className="min-w-[200px]">
-                                      <SelectItem
-                                        value="edit"
-                                        onSelect={() => setSelectedWebhookId(webhook.id)}
-                                      >
-                                        <Activity className="h-4 w-4 mr-2" />
-                                        Historique
-                                      </SelectItem>
-                                      <SelectItem
-                                        value="delete"
-                                        onSelect={() => handleTest(webhook)}
-                                        disabled={testWebhook.isPending}
-                                      >
-                                        <TestTube className="h-4 w-4 mr-2" />
-                                        Tester
-                                      </SelectItem>
-                                      <SelectItem
-                                        value="copy"
-                                        onSelect={() => handleOpenDialog(webhook)}
-                                      >
-                                        <Edit className="h-4 w-4 mr-2" />
-                                        Modifier
-                                      </SelectItem>
-                                      <SelectItem
-                                        value="view"
-                                        onSelect={() => handleDelete(webhook)}
-                                        disabled={deleteWebhook.isPending}
-                                        className="text-destructive"
-                                      >
-                                        <Trash2 className="h-4 w-4 mr-2" />
-                                        Supprimer
-                                      </SelectItem>
-                                    </SelectContent>
-                                  </Select>
-                                </div>
-
-                                <div className="space-y-2 pt-3 border-t border-border/50">
-                                  <div className="flex items-center justify-between">
-                                    <p className="text-xs text-muted-foreground">URL</p>
-                                    <code className="text-xs bg-muted/50 px-2 py-1 rounded truncate max-w-[200px] font-mono">
-                                      {webhook.url}
-                                    </code>
-                                  </div>
-                                  <div className="flex items-center justify-between">
-                                    <p className="text-xs text-muted-foreground">Statistiques</p>
-                                    <div className="text-xs text-muted-foreground text-right">
-                                      <div>✓ {webhook.successful_deliveries} réussies</div>
-                                      <div>✗ {webhook.failed_deliveries} échecs</div>
-                                    </div>
-                                  </div>
-                                  <div className="flex items-center justify-between">
-                                    <p className="text-xs text-muted-foreground">
-                                      Dernière livraison
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                      {webhook.last_triggered_at
-                                        ? format(new Date(webhook.last_triggered_at), 'PPp', {
-                                            locale: fr,
-                                          })
-                                        : 'Jamais'}
-                                    </p>
-                                  </div>
-                                </div>
-                              </CardContent>
-                            </Card>
-                          ))}
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
                         </div>
-                      )}
-                    </>
-                  ) : (
-                    <div className="text-center py-12 sm:py-16">
-                      <div className="p-4 rounded-full bg-gradient-to-br from-purple-500/10 to-pink-500/5 mb-4 animate-in zoom-in duration-500 inline-block">
-                        <WebhookIcon className="h-12 w-12 sm:h-16 sm:w-16 text-muted-foreground opacity-20" />
-                      </div>
-                      <p className="text-sm sm:text-base text-foreground font-medium mb-2">
-                        Aucun webhook configuré
-                      </p>
-                      <p className="text-xs sm:text-sm text-muted-foreground">
-                        Créez votre premier webhook pour commencer.
-                      </p>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
 
-              {/* Deliveries History */}
-              {selectedWebhookId && deliveries && (
-                <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
-                  <CardHeader>
-                    <CardTitle className="text-base sm:text-lg">
-                      Historique des Livraisons
-                    </CardTitle>
-                    <CardDescription className="text-xs sm:text-sm">
-                      Historique des tentatives de livraison pour ce webhook
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    {deliveries.length > 0 ? (
-                      <>
-                        {/* Desktop Table View */}
-                        <div className="hidden lg:block">
-                          <div className="border border-border/50 rounded-lg overflow-hidden">
-                            <Table>
-                              <TableHeader>
-                                <TableRow className="bg-muted/50">
-                                  <TableHead className="text-xs sm:text-sm font-semibold">
-                                    Événement
-                                  </TableHead>
-                                  <TableHead className="text-xs sm:text-sm font-semibold">
-                                    Statut
-                                  </TableHead>
-                                  <TableHead className="text-xs sm:text-sm font-semibold">
-                                    Date
-                                  </TableHead>
-                                  <TableHead className="text-xs sm:text-sm font-semibold">
-                                    Réponse
-                                  </TableHead>
-                                  <TableHead className="text-right text-xs sm:text-sm font-semibold">
-                                    Actions
-                                  </TableHead>
-                                </TableRow>
-                              </TableHeader>
-                              <TableBody>
-                                {deliveries.map(delivery => (
-                                  <TableRow
-                                    key={delivery.id}
-                                    className="hover:bg-muted/50 transition-colors"
-                                  >
-                                    <TableCell>
-                                      <Badge variant="outline" className="text-xs">
-                                        {delivery.event_type}
-                                      </Badge>
-                                    </TableCell>
-                                    <TableCell>{getDeliveryStatusBadge(delivery.status)}</TableCell>
-                                    <TableCell className="text-xs sm:text-sm text-muted-foreground">
-                                      {format(new Date(delivery.triggered_at), 'PPp', {
-                                        locale: fr,
-                                      })}
-                                    </TableCell>
-                                    <TableCell>
-                                      {delivery.response_status_code ? (
-                                        <code className="text-xs bg-muted/50 px-2 py-1 rounded font-mono">
-                                          {delivery.response_status_code}
-                                        </code>
-                                      ) : (
-                                        <span className="text-xs text-muted-foreground">-</span>
-                                      )}
-                                    </TableCell>
-                                    <TableCell className="text-right">
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        onSelect={() => {
-                                          setViewingDelivery(delivery);
-                                          setIsViewDialogOpen(true);
-                                        }}
-                                        className="h-8 w-8 p-0"
-                                        aria-label={`Voir les détails de la livraison ${delivery.event_type}`}
-                                      >
-                                        <Eye className="h-3.5 w-3.5" aria-hidden="true" />
-                                      </Button>
-                                    </TableCell>
-                                  </TableRow>
-                                ))}
-                              </TableBody>
-                            </Table>
+                        <div className="space-y-2 pt-3 border-t border-border/50">
+                          <div className="flex items-center justify-between">
+                            <p className="text-xs text-muted-foreground">URL</p>
+                            <code className="text-xs bg-muted/50 px-2 py-1 rounded truncate max-w-[200px] font-mono">
+                              {webhook.url}
+                            </code>
+                          </div>
+                          <div className="flex items-center justify-between">
+                            <p className="text-xs text-muted-foreground">Statistiques</p>
+                            <div className="text-xs text-muted-foreground text-right">
+                              <div>✓ {webhook.successful_deliveries} réussies</div>
+                              <div>✗ {webhook.failed_deliveries} échecs</div>
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-between">
+                            <p className="text-xs text-muted-foreground">Dernière livraison</p>
+                            <p className="text-xs text-muted-foreground">
+                              {webhook.last_triggered_at
+                                ? format(new Date(webhook.last_triggered_at), 'PPp', {
+                                    locale: fr,
+                                  })
+                                : 'Jamais'}
+                            </p>
                           </div>
                         </div>
-
-                        {/* Mobile Card View */}
-                        <div className="lg:hidden space-y-3 sm:space-y-4">
-                          {deliveries.map(delivery => (
-                            <Card
-                              key={delivery.id}
-                              className="border-border/50 bg-card/50 backdrop-blur-sm"
-                            >
-                              <CardContent className="p-4 sm:p-5">
-                                <div className="flex items-start justify-between mb-3">
-                                  <div className="flex-1">
-                                    <div className="flex items-center gap-2 mb-2">
-                                      <Badge variant="outline" className="text-xs">
-                                        {delivery.event_type}
-                                      </Badge>
-                                      {getDeliveryStatusBadge(delivery.status)}
-                                    </div>
-                                    <p className="text-xs text-muted-foreground mb-1">
-                                      {format(new Date(delivery.triggered_at), 'PPp', {
-                                        locale: fr,
-                                      })}
-                                    </p>
-                                    {delivery.response_status_code && (
-                                      <code className="text-xs bg-muted/50 px-2 py-1 rounded font-mono">
-                                        {delivery.response_status_code}
-                                      </code>
-                                    )}
-                                  </div>
-                                  <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onSelect={() => {
-                                      setViewingDelivery(delivery);
-                                      setIsViewDialogOpen(true);
-                                    }}
-                                    className="h-8 w-8 p-0"
-                                    aria-label={`Voir les détails de la livraison ${delivery.event_type}`}
-                                  >
-                                    <Eye className="h-4 w-4" aria-hidden="true" />
-                                  </Button>
-                                </div>
-                              </CardContent>
-                            </Card>
-                          ))}
-                        </div>
-                      </>
-                    ) : (
-                      <div className="text-center py-12 sm:py-16">
-                        <div className="p-4 rounded-full bg-gradient-to-br from-purple-500/10 to-pink-500/5 mb-4 animate-in zoom-in duration-500 inline-block">
-                          <Activity className="h-12 w-12 sm:h-16 sm:w-16 text-muted-foreground opacity-20" />
-                        </div>
-                        <p className="text-sm sm:text-base text-foreground font-medium mb-2">
-                          Aucune livraison enregistrée
-                        </p>
-                        <p className="text-xs sm:text-sm text-muted-foreground">
-                          Aucune livraison enregistrée pour ce webhook.
-                        </p>
-                      </div>
-                    )}
-                  </CardContent>
-                </Card>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
               )}
+            </>
+          ) : (
+            <div className="text-center py-12 sm:py-16">
+              <div className="p-4 rounded-full bg-gradient-to-br from-purple-500/10 to-pink-500/5 mb-4 animate-in zoom-in duration-500 inline-block">
+                <WebhookIcon className="h-12 w-12 sm:h-16 sm:w-16 text-muted-foreground opacity-20" />
+              </div>
+              <p className="text-sm sm:text-base text-foreground font-medium mb-2">
+                Aucun webhook configuré
+              </p>
+              <p className="text-xs sm:text-sm text-muted-foreground">
+                Créez votre premier webhook pour commencer.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
-              {/* Create/Edit Dialog */}
-              <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-                <DialogContent className="max-w-[90vw] sm:max-w-4xl max-h-[90vh] overflow-y-auto">
-                  <DialogHeader>
-                    <DialogTitle className="text-base sm:text-lg">
-                      {editingWebhook ? 'Modifier le Webhook' : 'Nouveau Webhook'}
-                    </DialogTitle>
-                    <DialogDescription className="text-xs sm:text-sm">
-                      Configurez un webhook pour recevoir des notifications en temps réel
-                    </DialogDescription>
-                  </DialogHeader>
-                  <form onSubmit={handleSubmit} className="space-y-3 sm:space-y-4">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="name" className="text-xs sm:text-sm">
-                          Nom *
-                        </Label>
-                        <Input
-                          id="name"
-                          value={formData.name}
-                          onChange={e => setFormData({ ...formData, name: e.target.value })}
-                          required
-                          placeholder="Mon Webhook"
-                          className="h-9 sm:h-10 text-xs sm:text-sm"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="status" className="text-xs sm:text-sm">
-                          Statut
-                        </Label>
-                        <Select
-                          value={formData.status}
-                          onValueChange={(value: WebhookStatus) =>
-                            setFormData({ ...formData, status: value })
-                          }
-                        >
-                          <SelectTrigger className="h-9 sm:h-10 text-xs sm:text-sm">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="active">Actif</SelectItem>
-                            <SelectItem value="inactive">Inactif</SelectItem>
-                            <SelectItem value="paused">En pause</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="description" className="text-xs sm:text-sm">
-                        Description
-                      </Label>
-                      <Textarea
-                        id="description"
-                        value={formData.description}
-                        onChange={e => setFormData({ ...formData, description: e.target.value })}
-                        placeholder="Description du webhook..."
-                        rows={2}
-                        className="text-xs sm:text-sm"
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="url" className="text-xs sm:text-sm">
-                        URL Endpoint *
-                      </Label>
-                      <Input
-                        id="url"
-                        type="url"
-                        value={formData.url}
-                        onChange={e => setFormData({ ...formData, url: e.target.value })}
-                        required
-                        placeholder="https://votre-domaine.com/webhooks/emarzona"
-                        className="h-9 sm:h-10 text-xs sm:text-sm"
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="secret" className="text-xs sm:text-sm">
-                        Secret (optionnel)
-                        <span className="text-xs text-muted-foreground ml-2">
-                          Pour signature HMAC-SHA256
-                        </span>
-                      </Label>
-                      <div className="flex gap-2">
-                        <Input
-                          id="secret"
-                          type="password"
-                          value={formData.secret}
-                          onChange={e => setFormData({ ...formData, secret: e.target.value })}
-                          placeholder="Laissez vide pour générer automatiquement"
-                          className="h-9 sm:h-10 text-xs sm:text-sm flex-1"
-                        />
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onSelect={() => {
-                            const newSecret = btoa(
-                              String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32)))
-                            ).slice(0, 32);
-                            setFormData({ ...formData, secret: newSecret });
-                          }}
-                          className="h-9 sm:h-10 text-xs sm:text-sm"
-                        >
-                          Générer
-                        </Button>
-                      </div>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label className="text-xs sm:text-sm">Événements à écouter *</Label>
-                      <div className="border border-border/50 rounded-md p-3 sm:p-4 max-h-64 overflow-y-auto">
-                        {WEBHOOK_EVENTS.map(category => (
-                          <div key={category.category} className="mb-3 sm:mb-4 last:mb-0">
-                            <h4 className="font-medium text-xs sm:text-sm mb-2">
-                              {category.category}
-                            </h4>
-                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                              {category.events.map(event => (
-                                <label
-                                  key={event.value}
-                                  className="flex items-center space-x-2 cursor-pointer hover:bg-muted/50 p-2 rounded transition-colors"
-                                >
-                                  <input
-                                    type="checkbox"
-                                    checked={formData.events?.includes(event.value)}
-                                    onChange={() => toggleEvent(event.value)}
-                                    className="rounded"
-                                  />
-                                  <span className="text-xs sm:text-sm">{event.label}</span>
-                                </label>
-                              ))}
-                            </div>
-                          </div>
+      {/* Deliveries History */}
+      {selectedWebhookId && deliveries && (
+        <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+          <CardHeader>
+            <CardTitle className="text-base sm:text-lg">Historique des Livraisons</CardTitle>
+            <CardDescription className="text-xs sm:text-sm">
+              Historique des tentatives de livraison pour ce webhook
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {deliveries.length > 0 ? (
+              <>
+                {/* Desktop Table View */}
+                <div className="hidden lg:block">
+                  <div className="border border-border/50 rounded-lg overflow-hidden">
+                    <Table>
+                      <TableHeader>
+                        <TableRow className="bg-muted/50">
+                          <TableHead className="text-xs sm:text-sm font-semibold">
+                            Événement
+                          </TableHead>
+                          <TableHead className="text-xs sm:text-sm font-semibold">Statut</TableHead>
+                          <TableHead className="text-xs sm:text-sm font-semibold">Date</TableHead>
+                          <TableHead className="text-xs sm:text-sm font-semibold">
+                            Réponse
+                          </TableHead>
+                          <TableHead className="text-right text-xs sm:text-sm font-semibold">
+                            Actions
+                          </TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {deliveries.map(delivery => (
+                          <TableRow
+                            key={delivery.id}
+                            className="hover:bg-muted/50 transition-colors"
+                          >
+                            <TableCell>
+                              <Badge variant="outline" className="text-xs">
+                                {delivery.event_type}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>{getDeliveryStatusBadge(delivery.status)}</TableCell>
+                            <TableCell className="text-xs sm:text-sm text-muted-foreground">
+                              {format(new Date(delivery.triggered_at), 'PPp', {
+                                locale: fr,
+                              })}
+                            </TableCell>
+                            <TableCell>
+                              {delivery.response_status_code ? (
+                                <code className="text-xs bg-muted/50 px-2 py-1 rounded font-mono">
+                                  {delivery.response_status_code}
+                                </code>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">-</span>
+                              )}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onSelect={() => {
+                                  setViewingDelivery(delivery);
+                                  setIsViewDialogOpen(true);
+                                }}
+                                className="h-8 w-8 p-0"
+                                aria-label={`Voir les détails de la livraison ${delivery.event_type}`}
+                              >
+                                <Eye className="h-3.5 w-3.5" aria-hidden="true" />
+                              </Button>
+                            </TableCell>
+                          </TableRow>
                         ))}
-                      </div>
-                      {formData.events && formData.events.length > 0 && (
-                        <p className="text-xs text-muted-foreground">
-                          {formData.events.length} événement(s) sélectionné(s)
-                        </p>
-                      )}
-                    </div>
+                      </TableBody>
+                    </Table>
+                  </div>
+                </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="retry_count" className="text-xs sm:text-sm">
-                          Tentatives de retry
-                        </Label>
-                        <Input
-                          id="retry_count"
-                          type="number"
-                          min="0"
-                          max="10"
-                          value={formData.retry_count}
-                          onChange={e =>
-                            setFormData({ ...formData, retry_count: parseInt(e.target.value) || 3 })
-                          }
-                          className="h-9 sm:h-10 text-xs sm:text-sm"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="timeout_seconds" className="text-xs sm:text-sm">
-                          Timeout (secondes)
-                        </Label>
-                        <Input
-                          id="timeout_seconds"
-                          type="number"
-                          min="5"
-                          max="300"
-                          value={formData.timeout_seconds}
-                          onChange={e =>
-                            setFormData({
-                              ...formData,
-                              timeout_seconds: parseInt(e.target.value) || 30,
-                            })
-                          }
-                          className="h-9 sm:h-10 text-xs sm:text-sm"
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="rate_limit" className="text-xs sm:text-sm">
-                          Rate limit/min
-                        </Label>
-                        <Input
-                          id="rate_limit"
-                          type="number"
-                          min="1"
-                          value={formData.rate_limit_per_minute}
-                          onChange={e =>
-                            setFormData({
-                              ...formData,
-                              rate_limit_per_minute: parseInt(e.target.value) || 60,
-                            })
-                          }
-                          className="h-9 sm:h-10 text-xs sm:text-sm"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
-                      <div className="flex items-center space-x-2">
-                        <Switch
-                          id="verify_ssl"
-                          checked={formData.verify_ssl}
-                          onCheckedChange={checked =>
-                            setFormData({ ...formData, verify_ssl: checked })
-                          }
-                        />
-                        <Label htmlFor="verify_ssl" className="text-xs sm:text-sm">
-                          Vérifier SSL
-                        </Label>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <Switch
-                          id="include_payload"
-                          checked={formData.include_payload}
-                          onCheckedChange={checked =>
-                            setFormData({ ...formData, include_payload: checked })
-                          }
-                        />
-                        <Label htmlFor="include_payload" className="text-xs sm:text-sm">
-                          Inclure le payload
-                        </Label>
-                      </div>
-                    </div>
-
-                    <DialogFooter className="flex-col sm:flex-row gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onSelect={() => setIsDialogOpen(false)}
-                        className="w-full sm:w-auto h-9 sm:h-10 text-xs sm:text-sm"
-                      >
-                        Annuler
-                      </Button>
-                      <Button
-                        type="submit"
-                        disabled={!formData.name || !formData.url || !formData.events?.length}
-                        className="w-full sm:w-auto h-9 sm:h-10 text-xs sm:text-sm bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
-                      >
-                        {editingWebhook ? 'Enregistrer' : 'Créer'}
-                      </Button>
-                    </DialogFooter>
-                  </form>
-                </DialogContent>
-              </Dialog>
-
-              {/* View Delivery Dialog */}
-              <Dialog open={isViewDialogOpen} onOpenChange={setIsViewDialogOpen}>
-                <DialogContent className="max-w-[90vw] sm:max-w-3xl max-h-[90vh] overflow-y-auto">
-                  <DialogHeader>
-                    <DialogTitle className="text-base sm:text-lg">
-                      Détails de la Livraison
-                    </DialogTitle>
-                  </DialogHeader>
-                  {viewingDelivery && (
-                    <div className="space-y-3 sm:space-y-4">
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
-                        <div>
-                          <Label className="text-xs sm:text-sm">Statut</Label>
-                          <div className="mt-1">
-                            {getDeliveryStatusBadge(viewingDelivery.status)}
-                          </div>
-                        </div>
-                        <div>
-                          <Label className="text-xs sm:text-sm">Événement</Label>
-                          <div className="mt-1">
-                            <Badge variant="outline" className="text-xs">
-                              {viewingDelivery.event_type}
-                            </Badge>
-                          </div>
-                        </div>
-                        <div>
-                          <Label className="text-xs sm:text-sm">Date</Label>
-                          <div className="text-xs sm:text-sm text-muted-foreground mt-1">
-                            {format(new Date(viewingDelivery.triggered_at), 'PPp', { locale: fr })}
-                          </div>
-                        </div>
-                        <div>
-                          <Label className="text-xs sm:text-sm">Durée</Label>
-                          <div className="text-xs sm:text-sm text-muted-foreground mt-1">
-                            {viewingDelivery.duration_ms ? `${viewingDelivery.duration_ms}ms` : '-'}
-                          </div>
-                        </div>
-                        <div>
-                          <Label className="text-xs sm:text-sm">Code HTTP</Label>
-                          <div className="mt-1">
-                            {viewingDelivery.response_status_code ? (
+                {/* Mobile Card View */}
+                <div className="lg:hidden space-y-3 sm:space-y-4">
+                  {deliveries.map(delivery => (
+                    <Card
+                      key={delivery.id}
+                      className="border-border/50 bg-card/50 backdrop-blur-sm"
+                    >
+                      <CardContent className="p-4 sm:p-5">
+                        <div className="flex items-start justify-between mb-3">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2 mb-2">
+                              <Badge variant="outline" className="text-xs">
+                                {delivery.event_type}
+                              </Badge>
+                              {getDeliveryStatusBadge(delivery.status)}
+                            </div>
+                            <p className="text-xs text-muted-foreground mb-1">
+                              {format(new Date(delivery.triggered_at), 'PPp', {
+                                locale: fr,
+                              })}
+                            </p>
+                            {delivery.response_status_code && (
                               <code className="text-xs bg-muted/50 px-2 py-1 rounded font-mono">
-                                {viewingDelivery.response_status_code}
+                                {delivery.response_status_code}
                               </code>
-                            ) : (
-                              <span className="text-xs text-muted-foreground">-</span>
                             )}
                           </div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onSelect={() => {
+                              setViewingDelivery(delivery);
+                              setIsViewDialogOpen(true);
+                            }}
+                            className="h-8 w-8 p-0"
+                            aria-label={`Voir les détails de la livraison ${delivery.event_type}`}
+                          >
+                            <Eye className="h-4 w-4" aria-hidden="true" />
+                          </Button>
                         </div>
-                        <div>
-                          <Label className="text-xs sm:text-sm">Tentative</Label>
-                          <div className="text-xs sm:text-sm text-muted-foreground mt-1">
-                            {viewingDelivery.attempt_number} / {viewingDelivery.max_attempts}
-                          </div>
-                        </div>
-                      </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="text-center py-12 sm:py-16">
+                <div className="p-4 rounded-full bg-gradient-to-br from-purple-500/10 to-pink-500/5 mb-4 animate-in zoom-in duration-500 inline-block">
+                  <Activity className="h-12 w-12 sm:h-16 sm:w-16 text-muted-foreground opacity-20" />
+                </div>
+                <p className="text-sm sm:text-base text-foreground font-medium mb-2">
+                  Aucune livraison enregistrée
+                </p>
+                <p className="text-xs sm:text-sm text-muted-foreground">
+                  Aucune livraison enregistrée pour ce webhook.
+                </p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
-                      {viewingDelivery.error_message && (
-                        <div>
-                          <Label className="text-xs sm:text-sm">Erreur</Label>
-                          <Alert variant="destructive" className="mt-2">
-                            <AlertCircle className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
-                            <AlertDescription className="text-xs sm:text-sm">
-                              {viewingDelivery.error_message}
-                            </AlertDescription>
-                          </Alert>
-                        </div>
-                      )}
-
-                      <div>
-                        <Label className="text-xs sm:text-sm">Request Body</Label>
-                        <div className="mt-2 p-3 sm:p-4 bg-muted/50 rounded-md max-h-64 overflow-y-auto">
-                          <pre className="text-xs">
-                            {viewingDelivery.request_body
-                              ? JSON.stringify(JSON.parse(viewingDelivery.request_body), null, 2)
-                              : '-'}
-                          </pre>
-                        </div>
-                      </div>
-
-                      {viewingDelivery.response_body && (
-                        <div>
-                          <Label className="text-xs sm:text-sm">Response Body</Label>
-                          <div className="mt-2 p-3 sm:p-4 bg-muted/50 rounded-md max-h-64 overflow-y-auto">
-                            <pre className="text-xs">{viewingDelivery.response_body}</pre>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  <DialogFooter>
-                    <Button
-                      onSelect={() => setIsViewDialogOpen(false)}
-                      className="w-full sm:w-auto h-9 sm:h-10 text-xs sm:text-sm"
-                    >
-                      Fermer
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
+      {/* Create/Edit Dialog */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-w-[90vw] sm:max-w-4xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="text-base sm:text-lg">
+              {editingWebhook ? 'Modifier le Webhook' : 'Nouveau Webhook'}
+            </DialogTitle>
+            <DialogDescription className="text-xs sm:text-sm">
+              Configurez un webhook pour recevoir des notifications en temps réel
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-3 sm:space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="name" className="text-xs sm:text-sm">
+                  Nom *
+                </Label>
+                <Input
+                  id="name"
+                  value={formData.name}
+                  onChange={e => setFormData({ ...formData, name: e.target.value })}
+                  required
+                  placeholder="Mon Webhook"
+                  className="h-9 sm:h-10 text-xs sm:text-sm"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="status" className="text-xs sm:text-sm">
+                  Statut
+                </Label>
+                <Select
+                  value={formData.status}
+                  onValueChange={(value: WebhookStatus) =>
+                    setFormData({ ...formData, status: value })
+                  }
+                >
+                  <SelectTrigger className="h-9 sm:h-10 text-xs sm:text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="active">Actif</SelectItem>
+                    <SelectItem value="inactive">Inactif</SelectItem>
+                    <SelectItem value="paused">En pause</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
-          </main>
-        </div>
-      </div>
-    </SidebarProvider>
+
+            <div className="space-y-2">
+              <Label htmlFor="description" className="text-xs sm:text-sm">
+                Description
+              </Label>
+              <Textarea
+                id="description"
+                value={formData.description}
+                onChange={e => setFormData({ ...formData, description: e.target.value })}
+                placeholder="Description du webhook..."
+                rows={2}
+                className="text-xs sm:text-sm"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="url" className="text-xs sm:text-sm">
+                URL Endpoint *
+              </Label>
+              <Input
+                id="url"
+                type="url"
+                value={formData.url}
+                onChange={e => setFormData({ ...formData, url: e.target.value })}
+                required
+                placeholder="https://votre-domaine.com/webhooks/emarzona"
+                className="h-9 sm:h-10 text-xs sm:text-sm"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="secret" className="text-xs sm:text-sm">
+                Secret (optionnel)
+                <span className="text-xs text-muted-foreground ml-2">
+                  Pour signature HMAC-SHA256
+                </span>
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="secret"
+                  type="password"
+                  value={formData.secret}
+                  onChange={e => setFormData({ ...formData, secret: e.target.value })}
+                  placeholder="Laissez vide pour générer automatiquement"
+                  className="h-9 sm:h-10 text-xs sm:text-sm flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onSelect={() => {
+                    const newSecret = btoa(
+                      String.fromCharCode(...crypto.getRandomValues(new Uint8Array(32)))
+                    ).slice(0, 32);
+                    setFormData({ ...formData, secret: newSecret });
+                  }}
+                  className="h-9 sm:h-10 text-xs sm:text-sm"
+                >
+                  Générer
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-xs sm:text-sm">Événements à écouter *</Label>
+              <div className="border border-border/50 rounded-md p-3 sm:p-4 max-h-64 overflow-y-auto">
+                {WEBHOOK_EVENTS.map(category => (
+                  <div key={category.category} className="mb-3 sm:mb-4 last:mb-0">
+                    <h4 className="font-medium text-xs sm:text-sm mb-2">{category.category}</h4>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {category.events.map(event => (
+                        <label
+                          key={event.value}
+                          className="flex items-center space-x-2 cursor-pointer hover:bg-muted/50 p-2 rounded transition-colors"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={formData.events?.includes(event.value)}
+                            onChange={() => toggleEvent(event.value)}
+                            className="rounded"
+                          />
+                          <span className="text-xs sm:text-sm">{event.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              {formData.events && formData.events.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {formData.events.length} événement(s) sélectionné(s)
+                </p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="retry_count" className="text-xs sm:text-sm">
+                  Tentatives de retry
+                </Label>
+                <Input
+                  id="retry_count"
+                  type="number"
+                  min="0"
+                  max="10"
+                  value={formData.retry_count}
+                  onChange={e =>
+                    setFormData({ ...formData, retry_count: parseInt(e.target.value) || 3 })
+                  }
+                  className="h-9 sm:h-10 text-xs sm:text-sm"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="timeout_seconds" className="text-xs sm:text-sm">
+                  Timeout (secondes)
+                </Label>
+                <Input
+                  id="timeout_seconds"
+                  type="number"
+                  min="5"
+                  max="300"
+                  value={formData.timeout_seconds}
+                  onChange={e =>
+                    setFormData({
+                      ...formData,
+                      timeout_seconds: parseInt(e.target.value) || 30,
+                    })
+                  }
+                  className="h-9 sm:h-10 text-xs sm:text-sm"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="rate_limit" className="text-xs sm:text-sm">
+                  Rate limit/min
+                </Label>
+                <Input
+                  id="rate_limit"
+                  type="number"
+                  min="1"
+                  value={formData.rate_limit_per_minute}
+                  onChange={e =>
+                    setFormData({
+                      ...formData,
+                      rate_limit_per_minute: parseInt(e.target.value) || 60,
+                    })
+                  }
+                  className="h-9 sm:h-10 text-xs sm:text-sm"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="verify_ssl"
+                  checked={formData.verify_ssl}
+                  onCheckedChange={checked => setFormData({ ...formData, verify_ssl: checked })}
+                />
+                <Label htmlFor="verify_ssl" className="text-xs sm:text-sm">
+                  Vérifier SSL
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="include_payload"
+                  checked={formData.include_payload}
+                  onCheckedChange={checked =>
+                    setFormData({ ...formData, include_payload: checked })
+                  }
+                />
+                <Label htmlFor="include_payload" className="text-xs sm:text-sm">
+                  Inclure le payload
+                </Label>
+              </div>
+            </div>
+
+            <DialogFooter className="flex-col sm:flex-row gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onSelect={() => setIsDialogOpen(false)}
+                className="w-full sm:w-auto h-9 sm:h-10 text-xs sm:text-sm"
+              >
+                Annuler
+              </Button>
+              <Button
+                type="submit"
+                disabled={!formData.name || !formData.url || !formData.events?.length}
+                className="w-full sm:w-auto h-9 sm:h-10 text-xs sm:text-sm bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
+              >
+                {editingWebhook ? 'Enregistrer' : 'Créer'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* View Delivery Dialog */}
+      <Dialog open={isViewDialogOpen} onOpenChange={setIsViewDialogOpen}>
+        <DialogContent className="max-w-[90vw] sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="text-base sm:text-lg">Détails de la Livraison</DialogTitle>
+          </DialogHeader>
+          {viewingDelivery && (
+            <div className="space-y-3 sm:space-y-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+                <div>
+                  <Label className="text-xs sm:text-sm">Statut</Label>
+                  <div className="mt-1">{getDeliveryStatusBadge(viewingDelivery.status)}</div>
+                </div>
+                <div>
+                  <Label className="text-xs sm:text-sm">Événement</Label>
+                  <div className="mt-1">
+                    <Badge variant="outline" className="text-xs">
+                      {viewingDelivery.event_type}
+                    </Badge>
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs sm:text-sm">Date</Label>
+                  <div className="text-xs sm:text-sm text-muted-foreground mt-1">
+                    {format(new Date(viewingDelivery.triggered_at), 'PPp', { locale: fr })}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs sm:text-sm">Durée</Label>
+                  <div className="text-xs sm:text-sm text-muted-foreground mt-1">
+                    {viewingDelivery.duration_ms ? `${viewingDelivery.duration_ms}ms` : '-'}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs sm:text-sm">Code HTTP</Label>
+                  <div className="mt-1">
+                    {viewingDelivery.response_status_code ? (
+                      <code className="text-xs bg-muted/50 px-2 py-1 rounded font-mono">
+                        {viewingDelivery.response_status_code}
+                      </code>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">-</span>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs sm:text-sm">Tentative</Label>
+                  <div className="text-xs sm:text-sm text-muted-foreground mt-1">
+                    {viewingDelivery.attempt_number} / {viewingDelivery.max_attempts}
+                  </div>
+                </div>
+              </div>
+
+              {viewingDelivery.error_message && (
+                <div>
+                  <Label className="text-xs sm:text-sm">Erreur</Label>
+                  <Alert variant="destructive" className="mt-2">
+                    <AlertCircle className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+                    <AlertDescription className="text-xs sm:text-sm">
+                      {viewingDelivery.error_message}
+                    </AlertDescription>
+                  </Alert>
+                </div>
+              )}
+
+              <div>
+                <Label className="text-xs sm:text-sm">Request Body</Label>
+                <div className="mt-2 p-3 sm:p-4 bg-muted/50 rounded-md max-h-64 overflow-y-auto">
+                  <pre className="text-xs">
+                    {viewingDelivery.request_body
+                      ? JSON.stringify(JSON.parse(viewingDelivery.request_body), null, 2)
+                      : '-'}
+                  </pre>
+                </div>
+              </div>
+
+              {viewingDelivery.response_body && (
+                <div>
+                  <Label className="text-xs sm:text-sm">Response Body</Label>
+                  <div className="mt-2 p-3 sm:p-4 bg-muted/50 rounded-md max-h-64 overflow-y-auto">
+                    <pre className="text-xs">{viewingDelivery.response_body}</pre>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+          <DialogFooter>
+            <Button
+              onSelect={() => setIsViewDialogOpen(false)}
+              className="w-full sm:w-auto h-9 sm:h-10 text-xs sm:text-sm"
+            >
+              Fermer
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </WebhookPageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Unifie les commissions et retraits sur la source canonique `platform_settings` (singleton), supprime l'écriture en double depuis AdminSettings et le JSON customization.
- Ajoute Newsletter dans la navigation admin avec RBAC `settings.manage`, et corrige l'accès à `/admin/newsletter-subscribers`.
- Rend `/admin/webhooks` opérationnel côté plateforme avec `AdminLayout` et sélecteur de boutique, sans exiger une boutique vendeur.
- Corrige les routes mortes affichées dans `FeaturesSection` (coupons, vendeurs, annonces, wishlist, abonnements, factures).

## Test plan
- [ ] Ouvrir `/admin/settings` : vérifier le lien vers `/admin/commission-settings` et la sauvegarde des notifications email/SMS.
- [ ] Ouvrir `/admin/commission-settings` : confirmer que les taux commission/retrait restent la seule source modifiable.
- [ ] Ouvrir `/admin/platform-customization?section=settings` : vérifier l'alerte de redirection et l'absence d'édition commission/retrait en double.
- [ ] Se connecter avec un admin ayant `settings.manage` : accéder à `/admin/newsletter-subscribers` via le menu Configuration.
- [ ] Ouvrir `/admin/webhooks` sans boutique vendeur : sélectionner une boutique et créer/lister des webhooks.
- [ ] Vérifier dans Personnalisation > Fonctionnalités que les routes affichées pointent vers des pages existantes.
- [ ] Lancer `npx vitest run src/lib/admin/__tests__/customization-settings.test.ts src/lib/admin/__tests__/admin-route-permissions.test.ts`.

Made with [Cursor](https://cursor.com)